### PR TITLE
Add max payload size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+install:
+	rm -rf ~/.vscode/extensions/kite.vscode
+	mkdir -p ~/.vscode/extensions/kite.vscode
+	cp extension.js package.json README.md ~/.vscode/extensions/kite.vscode

--- a/extension.js
+++ b/extension.js
@@ -8,7 +8,16 @@ var http = require('http')
 
 var PLUGIN_ID = null;
 const SOURCE = "vscode";
+
+// MAX_TEXT_SIZE is a limit on the number of bytes in the text buffer.
+// Above this limit, events will not contain the contents of the buffer.
 const MAX_TEXT_SIZE = Math.pow(2, 20);
+
+// MAX_PAYLOAD_SIZE is a limit on the number of bytes in the body of each HTTP
+// request, after encoding the full JSON object. Given the MAX_TEXT_SIZE
+// limit, this limit should never be exceeded, but we still have it just in
+// case.
+const MAX_PAYLOAD_SIZE = Math.pow(2, 21);
 
 // Called when VSCode is started
 function activate (context) {


### PR DESCRIPTION
This pr adds a max payload size, separate from the max length of the text buffer. Previously this was causing an issue because the symbol was undefined.