### PR TITLE
Feature health metrics

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,10 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
-            "stopOnEntry": false
+            "stopOnEntry": false,
+            "env": {
+                "NODE_ENV": "development"
+            }
         },
         {
             "name": "Launch Tests",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "test": "node ./node_modules/vscode/bin/test"
   },
   "dependencies": {
+    "analytics-node": "^3.1.1",
     "atob": "^2.0.3",
     "formidable": "^1.1.1",
     "kite-installer": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "analytics-node": "^3.1.1",
     "atob": "^2.0.3",
     "formidable": "^1.1.1",
+    "getmac": "^1.2.1",
     "kite-installer": "^0.23.0",
     "md5": "^2.2.0",
     "opn": "^1.0.0",

--- a/src/kite.js
+++ b/src/kite.js
@@ -292,6 +292,23 @@ const Kite = {
     this.pollingInterval = setInterval(() => {
       this.checkState();
     }, config.get('pollingInterval'));
+
+    // We monitor kited health
+    setInterval(checkHealth, 60 * 1000 * 10);
+    checkHealth();
+
+    function checkHealth() {
+      StateController.handleState().then(state => {
+        switch (state) {
+          case 0: return metrics.trackHealth('unsupported');
+          case 1: return metrics.trackHealth('uninstalled');
+          case 2: return metrics.trackHealth('installed');
+          case 3: return metrics.trackHealth('running');
+          case 4: return metrics.trackHealth('reachable');
+          case 5: return metrics.trackHealth('authenticated');
+        }
+      });
+    }
   },
   
   deactivate() {

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -20,6 +20,13 @@ const ANALYTICS = new Segment(
 
 let Kite;
 
+let macaddress;
+
+require('getmac').getMac((err, mac) => {
+  if (err) { throw err; }
+  macaddress = mac;
+});
+
 // Generate a unique ID for this user and save it for future use.
 function distinctID() {
   var id = localconfig.get('distinctID');
@@ -61,14 +68,14 @@ function track(event, properties = {}) {
     properties
   };
   
-  Logger.debug('segment:', e);
+  Logger.debug('segment:', e);)
   
-  if (process.env.NODE_ENV !== 'test') { ANALYTICS.track(e); }
+  if (process.env.NODE_ENV !== 'test' && macaddress) { ANALYTICS.track(e); }
 }
 
 function trackHealth(value) {
   track('kited_health', {
-    user_id: distinctID(),
+    user_id: macaddress,
     sent_at: Math.floor(new Date().getTime() / 1000),
     source: 'vscode',
     os_name: getOsName(),

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -54,27 +54,26 @@ function featureFulfilled(name) {
   sendFeatureMetric(`atom_${name}_fulfilled`);
 }
 
-function track(event, props = {}) {
+function track(event, properties = {}) {
   const e = {
     event,
     userId: '0',
-    user_id: distinctID(),
-    sent_at: Math.floor(new Date().getTime() / 1000),
-    source: 'vscode',
+    properties
   };
-
-  for (const k in props) { e[k] = props[k]; }
-
+  
   Logger.debug('segment:', e);
-
+  
   if (process.env.NODE_ENV !== 'test') { ANALYTICS.track(e); }
 }
 
 function trackHealth(value) {
   track('kited_health', {
-    value,
+    user_id: distinctID(),
+    sent_at: Math.floor(new Date().getTime() / 1000),
+    source: 'vscode',
     os_name: getOsName(),
     plugin_version: kitePkg.version,
+    value,
   });
 }
 

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -68,7 +68,7 @@ function track(event, properties = {}) {
     properties
   };
   
-  Logger.debug('segment:', e);)
+  Logger.debug('segment:', e);
   
   if (process.env.NODE_ENV !== 'test' && macaddress) { ANALYTICS.track(e); }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -6,7 +6,7 @@ const {Logger} = require('kite-installer');
 const {head, last} = require('./utils');
 
 module.exports = {
-  PORT: 45667,
+  PORT: process.env.NODE_ENV === 'development' ? 45668 : 45667,
   routes: [],
   addRoute(method, route, handle) {
     this.routes.push([method, route, handle]);


### PR DESCRIPTION
This PR implements the `kited_health` metric sent to Segment. 

The switch between development and production mode is done using the `process.env.NODE_ENV` variable that is defined in our launch configuration.

No events are sent when running tests.

The `userId` field can't be `0` as it seems the nodejs lib is validating it, `'0'` makes the validation pass.

