### PR TITLE
Remove render of SO links

### DIFF
--- a/src/html-utils.js
+++ b/src/html-utils.js
@@ -197,7 +197,6 @@ function renderModule(data) {
       ${renderUsages(data)}
       ${renderExamples(data)}
       ${renderDefinition(data)}
-      ${renderLinks(data)}
       ${debugData(data)}
     </div>
   </div>
@@ -229,7 +228,6 @@ function renderFunction(data) {
       ${renderUsages(data)}
       ${renderExamples(data)}
       ${renderDefinition(data)}
-      ${renderLinks(data)}
       ${renderInvocations(symbol)}
       ${debugData(data)}
     </div>
@@ -259,7 +257,6 @@ function renderInstance(data) {
       ${renderUsages(data)}
       ${renderExamples(data)}
       ${renderDefinition(symbol)}
-      ${renderLinks(data)}
       ${debugData(data)}
     </div>
   </div>

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -6,7 +6,7 @@ const {fixtureURI, withRoutes, withKiteWhitelistedPaths, fakeResponse, log} = re
 const {asArray} = require('../src/html-utils');
 
 const {
-  hasMembersSection, hasDocsSection, hasHeaderSection, hasExamplesSection, hasLinksSection,
+  hasMembersSection, hasDocsSection, hasHeaderSection, hasExamplesSection,
   hasArgumentsSection, hasUsagesSection,
 } = require('./section-helpers');
 
@@ -44,8 +44,6 @@ describe('router', () => {
         hasDocsSection(source.report.description_html);
         
         hasExamplesSection(2, source.symbol.id, source.report.examples);
-        
-        hasLinksSection(2, source.symbol.id, source.report.links);
       });
 
       describe('for a type', () => {
@@ -100,8 +98,6 @@ describe('router', () => {
         hasUsagesSection(source.report.usages);
   
         hasExamplesSection(2, source.symbol.id, source.report.examples);
-        
-        hasLinksSection(2, source.symbol.id, source.report.links);
       });
 
       describe('for an instance', () => {
@@ -153,8 +149,6 @@ describe('router', () => {
         hasDocsSection(source.report.description_html);
         
         hasExamplesSection(2, source.symbol.id, source.report.examples);
-        
-        hasLinksSection(2, source.symbol.id, source.report.links);
       });
 
       describe('for a type', () => {
@@ -209,8 +203,6 @@ describe('router', () => {
         hasUsagesSection(source.report.usages);
   
         hasExamplesSection(2, source.symbol.id, source.report.examples);
-        
-        hasLinksSection(2, source.symbol.id, source.report.links);
       });
 
       describe('for an instance', () => {
@@ -262,8 +254,6 @@ describe('router', () => {
         hasDocsSection(source.report.description_html);
         
         hasExamplesSection(2, source.symbol.id, source.report.examples);
-        
-        hasLinksSection(2, source.symbol.id, source.report.links);
       });
 
       describe('for a type', () => {
@@ -318,8 +308,6 @@ describe('router', () => {
         hasUsagesSection(source.report.usages);
   
         hasExamplesSection(2, source.symbol.id, source.report.examples);
-        
-        hasLinksSection(2, source.symbol.id, source.report.links);
       });
 
       describe('for an instance', () => {
@@ -388,8 +376,6 @@ describe('router', () => {
         hasUsagesSection(source.report.usages);
   
         hasExamplesSection(2, source.symbol[0].id, source.report.examples);
-        
-        hasLinksSection(2, source.symbol[0].id, source.report.links);
       });
     });
 


### PR DESCRIPTION
Closes #107

The HTML helpers to build the list and the styles are still there, let me know if you think it should be completely removed.