### PR TITLE
Guard against selection with null start and end

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -117,7 +117,7 @@ module.exports = class EditorEvents {
       filename: normalizeDriveLetter(document.fileName),
     };
 
-    if (selection) {
+    if (selection && selection.start != null && selection.end != null) {
       event.selections = [{
         start: document.offsetAt(selection.start),
         end: document.offsetAt(selection.end),


### PR DESCRIPTION
We've seen an unusual amount of errors on rollbar caused by an attempt to compute the offset of a null position when creating an event object. We should never try to compute an offset if the selection object doesn't have start or end position.