### PR TITLE
Remove dependency on kite-installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
         "getmac": "^1.2.1",
         "kite-api": "^3.3.0",
         "kite-connector": "^3.4.0",
-        "kite-installer": "^3.0.2",
         "md5": "^2.2.0",
         "opn": "^5.0.0",
         "rollbar": "^2.3.8",

--- a/src/completion.js
+++ b/src/completion.js
@@ -9,7 +9,7 @@ const {
   window,
   workspace
 } = require("vscode");
-const { Logger } = require("kite-installer");
+const Logger = require("kite-connector/lib/logger");
 const {
   KITE_BRANDING,
   OFFSET_ENCODING,

--- a/src/kite.js
+++ b/src/kite.js
@@ -1,92 +1,109 @@
-'use strict';
+"use strict";
 
-const vscode = require('vscode');
-const os = require('os');
-const opn = require('opn');
-const KiteAPI = require('kite-api');
-const {Logger} = require('kite-installer');
-const {PYTHON_MODE, ERROR_COLOR, SUPPORTED_EXTENSIONS} = require('./constants');
-const KiteHoverProvider = require('./hover');
-const KiteCompletionProvider = require('./completion');
-const KiteSignatureProvider = require('./signature');
-const KiteDefinitionProvider = require('./definition');
-const KiteEditor = require('./kite-editor');
-const EditorEvents = require('./events');
-const localconfig = require('./localconfig');
-const metrics = require('./metrics');
-const server = require('./server');
-const {statusPath, languagesPath, hoverPath} = require('./urls');
-const Rollbar = require('rollbar');
-const {editorsForDocument, promisifyReadResponse, params, kiteOpen} = require('./utils');
-const {version} = require('../package.json');
+const vscode = require("vscode");
+const os = require("os");
+const opn = require("opn");
+const KiteAPI = require("kite-api");
+const Logger = require("kite-connector/lib/logger");
+const {
+  PYTHON_MODE,
+  ERROR_COLOR,
+  SUPPORTED_EXTENSIONS
+} = require("./constants");
+const KiteHoverProvider = require("./hover");
+const KiteCompletionProvider = require("./completion");
+const KiteSignatureProvider = require("./signature");
+const KiteDefinitionProvider = require("./definition");
+const KiteEditor = require("./kite-editor");
+const EditorEvents = require("./events");
+const localconfig = require("./localconfig");
+const metrics = require("./metrics");
+const server = require("./server");
+const { statusPath, languagesPath, hoverPath } = require("./urls");
+const Rollbar = require("rollbar");
+const {
+  editorsForDocument,
+  promisifyReadResponse,
+  params,
+  kiteOpen
+} = require("./utils");
+const { version } = require("../package.json");
 
 const Kite = {
   activate(ctx) {
-    if(process.env.NODE_ENV !== 'test') {
-      this._activate()
+    if (process.env.NODE_ENV !== "test") {
+      this._activate();
       ctx.subscriptions.push(this);
     }
   },
 
   _activate() {
-    metrics.featureRequested('starting');
+    metrics.featureRequested("starting");
 
     this.reset();
 
     const rollbar = new Rollbar({
-      accessToken: '4ca1bfd4721544e487c76583478a436a',
+      accessToken: "4ca1bfd4721544e487c76583478a436a",
       payload: {
         environment: process.env.NODE_ENV,
-        editor: 'vscode',
+        editor: "vscode",
         kite_plugin_version: version,
-        os: os.type() + ' ' + os.release(),
-      },
+        os: os.type() + " " + os.release()
+      }
     });
 
-    const tracker = (err) => {
-      if (err.stack.indexOf('kite') > -1) {
+    const tracker = err => {
+      if (err.stack.indexOf("kite") > -1) {
         rollbar.error(err);
       }
-    }
-    process.on('uncaughtException', tracker);
+    };
+    process.on("uncaughtException", tracker);
     this.disposables.push({
       dispose() {
-        process.removeListener('uncaughtException', tracker);
+        process.removeListener("uncaughtException", tracker);
       }
-    })
+    });
 
-    Logger.LEVEL = Logger.LEVELS[vscode.workspace.getConfiguration('kite').loggingLevel.toUpperCase()];
+    Logger.LEVEL =
+      Logger.LEVELS[
+        vscode.workspace.getConfiguration("kite").loggingLevel.toUpperCase()
+      ];
 
     KiteAPI.isKiteInstalled().catch(err => {
       if (err.message.includes("Unable to find Kite application install")) {
-        vscode.window.showInformationMessage('Unable to find Kite Engine. The Kite Engine is needed to power Kite\'s completions experience.', 'Install').then(item => {
-          if (item) {
-            switch(item) {
-              case 'Install':
-                opn('https://github.com/kiteco/vscode-plugin#installation');
-                break;
+        vscode.window
+          .showInformationMessage(
+            "Unable to find Kite Engine. The Kite Engine is needed to power Kite's completions experience.",
+            "Install"
+          )
+          .then(item => {
+            if (item) {
+              switch (item) {
+                case "Install":
+                  opn("https://github.com/kiteco/vscode-plugin#installation");
+                  break;
+              }
             }
-          }
-        });
+          });
       }
     });
 
     // send the activated event
-    metrics.track('activated');
+    metrics.track("activated");
 
     this.disposables.push(server);
 
-    server.addRoute('GET', '/check', (req, res) => {
-      this.checkState('/check route');
+    server.addRoute("GET", "/check", (req, res) => {
+      this.checkState("/check route");
       res.writeHead(200);
       res.end();
     });
 
-    server.addRoute('GET', '/count', (req, res, url) => {
-      const {metric, name} = params(url);
-      if (metric === 'requested') {
+    server.addRoute("GET", "/count", (req, res, url) => {
+      const { metric, name } = params(url);
+      if (metric === "requested") {
         metrics.featureRequested(name);
-      } else if (metric === 'fulfilled') {
+      } else if (metric === "fulfilled") {
         metrics.featureFulfilled(name);
       }
       res.writeHead(200);
@@ -96,204 +113,334 @@ const Kite = {
     server.start();
 
     this.disposables.push(
-      vscode.languages.registerHoverProvider(PYTHON_MODE, new KiteHoverProvider(Kite)));
+      vscode.languages.registerHoverProvider(
+        PYTHON_MODE,
+        new KiteHoverProvider(Kite)
+      )
+    );
     this.disposables.push(
-      vscode.languages.registerDefinitionProvider(PYTHON_MODE, new KiteDefinitionProvider(Kite)));
+      vscode.languages.registerDefinitionProvider(
+        PYTHON_MODE,
+        new KiteDefinitionProvider(Kite)
+      )
+    );
     this.disposables.push(
-      vscode.languages.registerCompletionItemProvider(PYTHON_MODE, new KiteCompletionProvider(Kite),
-      'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
-      'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
-      'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-      '.', '(', ',',' '
-      ));
+      vscode.languages.registerCompletionItemProvider(
+        PYTHON_MODE,
+        new KiteCompletionProvider(Kite),
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "i",
+        "j",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "q",
+        "r",
+        "s",
+        "t",
+        "u",
+        "v",
+        "w",
+        "x",
+        "y",
+        "z",
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+        "F",
+        "G",
+        "H",
+        "I",
+        "J",
+        "K",
+        "L",
+        "M",
+        "N",
+        "O",
+        "P",
+        "Q",
+        "R",
+        "S",
+        "T",
+        "U",
+        "V",
+        "W",
+        "X",
+        "Y",
+        "Z",
+        ".",
+        "(",
+        ",",
+        " "
+      )
+    );
     this.disposables.push(
-      vscode.languages.registerSignatureHelpProvider(PYTHON_MODE, new KiteSignatureProvider(Kite), '(', ','));
+      vscode.languages.registerSignatureHelpProvider(
+        PYTHON_MODE,
+        new KiteSignatureProvider(Kite),
+        "(",
+        ","
+      )
+    );
 
-    this.disposables.push(vscode.workspace.onDidChangeConfiguration(() => {
-      Logger.LEVEL = Logger.LEVELS[vscode.workspace.getConfiguration('kite').loggingLevel.toUpperCase()];
-    }));
-
-    this.disposables.push(vscode.window.onDidChangeActiveTextEditor(e => {
-      this.setStatusBarLabel();
-      if (e) {
-        if (/Code[\/\\]User[\/\\]settings.json$/.test(e.document.fileName)){
-          metrics.featureRequested('settings');
-          metrics.featureFulfilled('settings');
-        }
-        if (this.isGrammarSupported(e)) {
-          this.registerEvents(e);
-          this.registerEditor(e);
-        }
-
-        const evt = this.eventsByEditor.get(e.document.fileName);
-        evt && evt.focus();
-      }
-    }));
-
-    this.disposables.push(vscode.window.onDidChangeTextEditorSelection(e => {
-      const evt = this.eventsByEditor.get(e.textEditor.document.fileName);
-      evt && evt.selectionChanged();
-    }));
-
-    this.disposables.push(vscode.workspace.onDidChangeTextDocument(e => {
-      e.document && editorsForDocument(e.document).forEach(e => {
-        const evt = this.eventsByEditor.get(e.document.fileName);
-        evt && evt.edit();
+    this.disposables.push(
+      vscode.workspace.onDidChangeConfiguration(() => {
+        Logger.LEVEL =
+          Logger.LEVELS[
+            vscode.workspace.getConfiguration("kite").loggingLevel.toUpperCase()
+          ];
       })
-    }));
+    );
 
-    this.disposables.push(vscode.window.onDidChangeVisibleTextEditors(editors => {
-      editors.forEach((e) => {
-        if (e.document.languageId === 'python') {
-          this.registerDocumentEvents(e.document);
-          this.registerDocument(e.document);
+    this.disposables.push(
+      vscode.window.onDidChangeActiveTextEditor(e => {
+        this.setStatusBarLabel();
+        if (e) {
+          if (/Code[\/\\]User[\/\\]settings.json$/.test(e.document.fileName)) {
+            metrics.featureRequested("settings");
+            metrics.featureFulfilled("settings");
+          }
+          if (this.isGrammarSupported(e)) {
+            this.registerEvents(e);
+            this.registerEditor(e);
+          }
+
+          const evt = this.eventsByEditor.get(e.document.fileName);
+          evt && evt.focus();
         }
       })
-    }));
+    );
 
-    this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);
-    this.statusBarItem.text = '𝕜𝕚𝕥𝕖';
+    this.disposables.push(
+      vscode.window.onDidChangeTextEditorSelection(e => {
+        const evt = this.eventsByEditor.get(e.textEditor.document.fileName);
+        evt && evt.selectionChanged();
+      })
+    );
+
+    this.disposables.push(
+      vscode.workspace.onDidChangeTextDocument(e => {
+        e.document &&
+          editorsForDocument(e.document).forEach(e => {
+            const evt = this.eventsByEditor.get(e.document.fileName);
+            evt && evt.edit();
+          });
+      })
+    );
+
+    this.disposables.push(
+      vscode.window.onDidChangeVisibleTextEditors(editors => {
+        editors.forEach(e => {
+          if (e.document.languageId === "python") {
+            this.registerDocumentEvents(e.document);
+            this.registerDocument(e.document);
+          }
+        });
+      })
+    );
+
+    this.statusBarItem = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Right
+    );
+    this.statusBarItem.text = "𝕜𝕚𝕥𝕖";
     this.statusBarItem.color = undefined;
     this.statusBarItem.show();
 
     this.disposables.push(this.statusBarItem);
 
-    this.disposables.push(vscode.commands.registerCommand('kite.login', () => {
-      kiteOpen('kite://home');
-    }));
-
-    this.disposables.push(vscode.commands.registerCommand('kite.open-settings', () => {
-      kiteOpen('kite://settings');
-    }));
-
-    this.disposables.push(vscode.commands.registerCommand('kite.open-copilot', () => {
-      kiteOpen('kite://home');
-    }));
-
-    this.disposables.push(vscode.commands.registerCommand('kite.more', ({id, source}) => {
-      metrics.track(`${source} See info clicked`);
-      kiteOpen(`kite://docs/${id}`);
-    }));
-
-    this.disposables.push(vscode.commands.registerCommand('kite.more-position', ({position, source}) => {
-      metrics.track(`${source} See info clicked`);
-      const doc = vscode.window.activeTextEditor.document;
-      const path = hoverPath(doc, position);
-      return this.request({path})
-      .then(data => JSON.parse(data))
-      .then(data => {
-        kiteOpen(`kite://docs/${data.symbol[0].id}`)
+    this.disposables.push(
+      vscode.commands.registerCommand("kite.login", () => {
+        kiteOpen("kite://home");
       })
-    }));
+    );
 
-    this.disposables.push(vscode.commands.registerCommand('kite.web-url', (url) => {
-      opn(url.replace(/;/g, '%3B'));
-    }));
-
-    this.disposables.push(vscode.commands.registerCommand('kite.def', ({file, line, character, source}) => {
-      metrics.track(`${source} Go to definition clicked`);
-      metrics.featureRequested('definition');
-      vscode.workspace.openTextDocument(vscode.Uri.file(file))
-      .then(doc => {
-        return vscode.window.showTextDocument(doc);
+    this.disposables.push(
+      vscode.commands.registerCommand("kite.open-settings", () => {
+        kiteOpen("kite://settings");
       })
-      .then(e => {
-        metrics.featureFulfilled('definition');
-        const newPosition = new vscode.Position(line - 1, character ? character - 1 : 0);
-        e.revealRange(new vscode.Range(
-          newPosition,
-          new vscode.Position(line - 1, 100)
-        ));
+    );
 
-        const newSelection = new vscode.Selection(newPosition, newPosition);
-        e.selection = newSelection;
+    this.disposables.push(
+      vscode.commands.registerCommand("kite.open-copilot", () => {
+        kiteOpen("kite://home");
       })
-    }));
+    );
 
-    this.disposables.push(vscode.commands.registerCommand('kite.help', () => {
-      opn('https://help.kite.com/category/46-vs-code-integration');
-    }));
-
-    this.disposables.push(vscode.commands.registerCommand('kite.docs-at-cursor', () => {
-      const editor = vscode.window.activeTextEditor;
-
-      if (editor) {
-        const pos = editor.selection.active;
-        const {document} = editor;
-
-        const path = hoverPath(document, pos)
-        KiteAPI.request({path})
-          .then(resp => {
-            if(resp.statusCode === 200) {
-              vscode.commands.executeCommand('kite.more-position', {
-                position: pos,
-                source: 'Command',
-              })
-            }
-          })
-      }
-    }));
-
-    this.disposables.push(vscode.commands.registerCommand('kite.usage', ({file, line, source}) => {
-      metrics.track(`${source} Go to usage clicked`);
-      metrics.featureRequested('usage');
-      vscode.workspace.openTextDocument(file).then(doc => {
-        metrics.featureFulfilled('usage');
-        editorsForDocument(doc).some(e => {
-          e.revealRange(new vscode.Range(
-            new vscode.Position(line - 1, 0),
-            new vscode.Position(line - 1, 100)
-          ));
-        });
+    this.disposables.push(
+      vscode.commands.registerCommand("kite.more", ({ id, source }) => {
+        metrics.track(`${source} See info clicked`);
+        kiteOpen(`kite://docs/${id}`);
       })
-    }));
+    );
 
-    const config = vscode.workspace.getConfiguration('kite');
-    if (config.showWelcomeNotificationOnStartup) {
-      vscode.window.showInformationMessage('Welcome to Kite for VS Code', 'Learn how to use Kite', "Don't show this again").then(item => {
-        if (item) {
-          switch(item) {
-            case 'Learn how to use Kite':
-              opn('http://help.kite.com/category/46-vs-code-integration');
-              break;
-            case "Don't show this again":
-              config.update('showWelcomeNotificationOnStartup', false, true);
-              break;
-          }
+    this.disposables.push(
+      vscode.commands.registerCommand(
+        "kite.more-position",
+        ({ position, source }) => {
+          metrics.track(`${source} See info clicked`);
+          const doc = vscode.window.activeTextEditor.document;
+          const path = hoverPath(doc, position);
+          return this.request({ path })
+            .then(data => JSON.parse(data))
+            .then(data => {
+              kiteOpen(`kite://docs/${data.symbol[0].id}`);
+            });
         }
-      });
+      )
+    );
+
+    this.disposables.push(
+      vscode.commands.registerCommand("kite.web-url", url => {
+        opn(url.replace(/;/g, "%3B"));
+      })
+    );
+
+    this.disposables.push(
+      vscode.commands.registerCommand(
+        "kite.def",
+        ({ file, line, character, source }) => {
+          metrics.track(`${source} Go to definition clicked`);
+          metrics.featureRequested("definition");
+          vscode.workspace
+            .openTextDocument(vscode.Uri.file(file))
+            .then(doc => {
+              return vscode.window.showTextDocument(doc);
+            })
+            .then(e => {
+              metrics.featureFulfilled("definition");
+              const newPosition = new vscode.Position(
+                line - 1,
+                character ? character - 1 : 0
+              );
+              e.revealRange(
+                new vscode.Range(
+                  newPosition,
+                  new vscode.Position(line - 1, 100)
+                )
+              );
+
+              const newSelection = new vscode.Selection(
+                newPosition,
+                newPosition
+              );
+              e.selection = newSelection;
+            });
+        }
+      )
+    );
+
+    this.disposables.push(
+      vscode.commands.registerCommand("kite.help", () => {
+        opn("https://help.kite.com/category/46-vs-code-integration");
+      })
+    );
+
+    this.disposables.push(
+      vscode.commands.registerCommand("kite.docs-at-cursor", () => {
+        const editor = vscode.window.activeTextEditor;
+
+        if (editor) {
+          const pos = editor.selection.active;
+          const { document } = editor;
+
+          const path = hoverPath(document, pos);
+          KiteAPI.request({ path }).then(resp => {
+            if (resp.statusCode === 200) {
+              vscode.commands.executeCommand("kite.more-position", {
+                position: pos,
+                source: "Command"
+              });
+            }
+          });
+        }
+      })
+    );
+
+    this.disposables.push(
+      vscode.commands.registerCommand(
+        "kite.usage",
+        ({ file, line, source }) => {
+          metrics.track(`${source} Go to usage clicked`);
+          metrics.featureRequested("usage");
+          vscode.workspace.openTextDocument(file).then(doc => {
+            metrics.featureFulfilled("usage");
+            editorsForDocument(doc).some(e => {
+              e.revealRange(
+                new vscode.Range(
+                  new vscode.Position(line - 1, 0),
+                  new vscode.Position(line - 1, 100)
+                )
+              );
+            });
+          });
+        }
+      )
+    );
+
+    const config = vscode.workspace.getConfiguration("kite");
+    if (config.showWelcomeNotificationOnStartup) {
+      vscode.window
+        .showInformationMessage(
+          "Welcome to Kite for VS Code",
+          "Learn how to use Kite",
+          "Don't show this again"
+        )
+        .then(item => {
+          if (item) {
+            switch (item) {
+              case "Learn how to use Kite":
+                opn("http://help.kite.com/category/46-vs-code-integration");
+                break;
+              case "Don't show this again":
+                config.update("showWelcomeNotificationOnStartup", false, true);
+                break;
+            }
+          }
+        });
     }
 
     setTimeout(() => {
       vscode.window.visibleTextEditors.forEach(e => {
-        if (e.document.languageId === 'python') {
+        if (e.document.languageId === "python") {
           this.registerEvents(e);
           this.registerEditor(e);
 
           if (e === vscode.window.activeTextEditor) {
-            const evt = this.eventsByEditor.get(e.document.fileName)
+            const evt = this.eventsByEditor.get(e.document.fileName);
             evt && evt.focus();
           }
         }
-      })
+      });
 
-      this.checkState('activationCheck');
+      this.checkState("activationCheck");
     }, 100);
 
     this.pollingInterval = setInterval(() => {
-      this.checkState('pollingInterval');
-    }, config.get('pollingInterval') || 5000);
+      this.checkState("pollingInterval");
+    }, config.get("pollingInterval") || 5000);
 
-    metrics.featureFulfilled('starting');
+    metrics.featureFulfilled("starting");
 
     return this;
   },
 
   reset() {
-    this.disposables && this.disposables.forEach((disposable) => {
-      disposable.dispose();
-    })
+    this.disposables &&
+      this.disposables.forEach(disposable => {
+        disposable.dispose();
+      });
     this.kiteEditorByEditor = new Map();
     this.eventsByEditor = new Map();
     this.supportedLanguages = [];
@@ -308,22 +455,22 @@ const Kite = {
   },
 
   deactivate() {
-    for(const [, ke] of this.kiteEditorByEditor) {
+    for (const [, ke] of this.kiteEditorByEditor) {
       ke && ke.dispose();
     }
-    for(const [, evt] of this.eventsByEditor) {
+    for (const [, evt] of this.eventsByEditor) {
       evt && evt.dispose();
     }
-    metrics.featureRequested('stopping');
+    metrics.featureRequested("stopping");
     // send the activated event
-    metrics.track('deactivated');
-    metrics.featureFulfilled('stopping');
+    metrics.track("deactivated");
+    metrics.featureFulfilled("stopping");
     this.dispose();
     this.reset();
   },
 
   dispose() {
-    this.disposables && this.disposables.forEach(d => d.dispose())
+    this.disposables && this.disposables.forEach(d => d.dispose());
     delete this.disposables;
   },
 
@@ -345,9 +492,13 @@ const Kite = {
   registerEditor(e) {
     if (this.kiteEditorByEditor.has(e.document.fileName)) {
       const ke = this.kiteEditorByEditor.get(e.document.fileName);
-      ke.editor = e
+      ke.editor = e;
     } else {
-      Logger.debug('register kite editor for', e.document.fileName, e.document.languageId);
+      Logger.debug(
+        "register kite editor for",
+        e.document.fileName,
+        e.document.languageId
+      );
       const ke = new KiteEditor(Kite, e);
       this.kiteEditorByEditor.set(e.document.fileName, ke);
     }
@@ -356,60 +507,87 @@ const Kite = {
   checkState(src) {
     return Promise.all([
       KiteAPI.checkHealth(),
-      this.getSupportedLanguages().catch(() => []),
-    ]).then(([state, languages]) => {
-      this.supportedLanguages = languages;
+      this.getSupportedLanguages().catch(() => [])
+    ])
+      .then(([state, languages]) => {
+        this.supportedLanguages = languages;
 
-      if (state > KiteAPI.STATES.INSTALLED) {
-        localconfig.set('wasInstalled', true);
-      }
+        if (state > KiteAPI.STATES.INSTALLED) {
+          localconfig.set("wasInstalled", true);
+        }
 
-      switch (state) {
-        case KiteAPI.STATES.UNSUPPORTED:
-          if (this.shown[state] || !this.isGrammarSupported(vscode.window.activeTextEditor)) { return state; }
-          this.shown[state] = true;
-          if (!KiteAPI.isOSSupported()) {
-            metrics.track('OS unsupported');
-          } else if (!KiteAPI.isOSVersionSupported()) {
-            metrics.track('OS version unsupported');
-          }
-          this.showErrorMessage('Sorry, the Kite engine is currently not supported on your platform');
-          break;
-        case KiteAPI.STATES.UNINSTALLED:
-          if (this.shown[state] || (vscode.window.activeTextEditor && !this.isGrammarSupported(vscode.window.activeTextEditor))) {
+        switch (state) {
+          case KiteAPI.STATES.UNSUPPORTED:
+            if (
+              this.shown[state] ||
+              !this.isGrammarSupported(vscode.window.activeTextEditor)
+            ) {
+              return state;
+            }
+            this.shown[state] = true;
+            if (!KiteAPI.isOSSupported()) {
+              metrics.track("OS unsupported");
+            } else if (!KiteAPI.isOSVersionSupported()) {
+              metrics.track("OS version unsupported");
+            }
+            this.showErrorMessage(
+              "Sorry, the Kite engine is currently not supported on your platform"
+            );
+            break;
+          case KiteAPI.STATES.UNINSTALLED:
+            if (
+              this.shown[state] ||
+              (vscode.window.activeTextEditor &&
+                !this.isGrammarSupported(vscode.window.activeTextEditor))
+            ) {
+              return state;
+            }
+            this.shown[state] = true;
+            break;
+          case KiteAPI.STATES.INSTALLED:
+            if (
+              !this.attemptedToStartKite &&
+              vscode.workspace.getConfiguration("kite").startKiteEngineOnStartup
+            ) {
+              KiteAPI.runKiteAndWait().then(() => this.checkState(src));
+              this.attemptedToStartKite = true;
+            }
+            break;
+          case KiteAPI.STATES.RUNNING:
+            if (
+              this.shown[state] ||
+              !this.isGrammarSupported(vscode.window.activeTextEditor)
+            ) {
+              return state;
+            }
+            break;
+          default:
+            if (this.isGrammarSupported(vscode.window.activeTextEditor)) {
+              this.registerEditor(vscode.window.activeTextEditor);
+            }
+            if (src && (src === "pollingInterval" || src === "activationCheck"))
+              this.lastPolledState = state;
             return state;
-          }
-          this.shown[state] = true;
-          break;
-        case KiteAPI.STATES.INSTALLED:
-          if(!this.attemptedToStartKite && vscode.workspace.getConfiguration('kite').startKiteEngineOnStartup) {
-            KiteAPI.runKiteAndWait().then(() => this.checkState(src));
-            this.attemptedToStartKite = true;
-          }
-          break;
-        case KiteAPI.STATES.RUNNING:
-          if (this.shown[state] || !this.isGrammarSupported(vscode.window.activeTextEditor)) { return state; }
-          break;
-        default:
-          if (this.isGrammarSupported(vscode.window.activeTextEditor)) {
-            this.registerEditor(vscode.window.activeTextEditor);
-          }
-          if(src && (src === 'pollingInterval' || src === 'activationCheck')) this.lastPolledState = state
-          return state;
-      }
-      //state caching for capturihg false positives in kited restart race condition
-      //we do this only for checkState invocations coming from the polling or initial activation
-      //script to eliminate the possible case where multiple editor events were generated quickly
-      //while kited was restarting
-      if(src && (src === 'pollingInterval' || src === 'activationCheck')) this.lastPolledState = state
-      return state;
-    })
-    .then(state => {
-      this.setStatus(state, this.isGrammarSupported(vscode.window.activeTextEditor) ? vscode.window.activeTextEditor.document : null);
-    })
-    .catch(err => {
-      console.error(err);
-    });
+        }
+        //state caching for capturihg false positives in kited restart race condition
+        //we do this only for checkState invocations coming from the polling or initial activation
+        //script to eliminate the possible case where multiple editor events were generated quickly
+        //while kited was restarting
+        if (src && (src === "pollingInterval" || src === "activationCheck"))
+          this.lastPolledState = state;
+        return state;
+      })
+      .then(state => {
+        this.setStatus(
+          state,
+          this.isGrammarSupported(vscode.window.activeTextEditor)
+            ? vscode.window.activeTextEditor.document
+            : null
+        );
+      })
+      .catch(err => {
+        console.error(err);
+      });
   },
 
   showErrorMessage(message, ...actions) {
@@ -432,59 +610,61 @@ const Kite = {
 
     const supported = this.isGrammarSupported(vscode.window.activeTextEditor);
 
-    if(supported) {
+    if (supported) {
       this.statusBarItem.show();
       switch (state) {
         case KiteAPI.STATES.UNSUPPORTED:
-          this.statusBarItem.tooltip = 'Kite engine is currently not supported on your platform';
+          this.statusBarItem.tooltip =
+            "Kite engine is currently not supported on your platform";
           this.statusBarItem.color = ERROR_COLOR;
-          this.statusBarItem.text = '𝕜𝕚𝕥𝕖: not supported';
+          this.statusBarItem.text = "𝕜𝕚𝕥𝕖: not supported";
           break;
         case KiteAPI.STATES.UNINSTALLED:
-          this.statusBarItem.text = '𝕜𝕚𝕥𝕖: not installed';
-          this.statusBarItem.tooltip = 'Kite engine is not installed';
+          this.statusBarItem.text = "𝕜𝕚𝕥𝕖: not installed";
+          this.statusBarItem.tooltip = "Kite engine is not installed";
           this.statusBarItem.color = ERROR_COLOR;
           break;
         case KiteAPI.STATES.INSTALLED:
-          this.statusBarItem.text = '𝕜𝕚𝕥𝕖: not running';
-          this.statusBarItem.tooltip = 'Kite engine is not running';
+          this.statusBarItem.text = "𝕜𝕚𝕥𝕖: not running";
+          this.statusBarItem.tooltip = "Kite engine is not running";
           this.statusBarItem.color = ERROR_COLOR;
           break;
         case KiteAPI.STATES.RUNNING:
-          this.statusBarItem.text = '𝕜𝕚𝕥𝕖: not reachable';
-          this.statusBarItem.tooltip = 'Kite engine is not reachable';
+          this.statusBarItem.text = "𝕜𝕚𝕥𝕖: not reachable";
+          this.statusBarItem.tooltip = "Kite engine is not reachable";
           this.statusBarItem.color = ERROR_COLOR;
           break;
         default:
-          if(status) {
-            switch(status.status) {
-              case 'indexing':
+          if (status) {
+            switch (status.status) {
+              case "indexing":
                 this.statusBarItem.color = undefined;
-                this.statusBarItem.text = '𝕜𝕚𝕥𝕖: indexing'
-                this.statusBarItem.tooltip = 'Kite engine is indexing your code';
+                this.statusBarItem.text = "𝕜𝕚𝕥𝕖: indexing";
+                this.statusBarItem.tooltip =
+                  "Kite engine is indexing your code";
                 break;
-              case 'syncing':
-                this.statusBarItem.text = '𝕜𝕚𝕥𝕖: syncing'
+              case "syncing":
+                this.statusBarItem.text = "𝕜𝕚𝕥𝕖: syncing";
                 this.statusBarItem.color = undefined;
-                this.statusBarItem.tooltip = 'Kite engine is syncing your code';
+                this.statusBarItem.tooltip = "Kite engine is syncing your code";
                 break;
-              case 'ready':
-                this.statusBarItem.text = '𝕜𝕚𝕥𝕖';
+              case "ready":
+                this.statusBarItem.text = "𝕜𝕚𝕥𝕖";
                 this.statusBarItem.color = undefined;
-                this.statusBarItem.tooltip = 'Kite is ready';
+                this.statusBarItem.tooltip = "Kite is ready";
                 break;
             }
           } else {
-            this.statusBarItem.text = '';
+            this.statusBarItem.text = "";
             this.statusBarItem.color = undefined;
-            this.statusBarItem.tooltip = '';
+            this.statusBarItem.tooltip = "";
             this.statusBarItem.hide();
           }
       }
     } else {
-      this.statusBarItem.text = '';
+      this.statusBarItem.text = "";
       this.statusBarItem.color = undefined;
-      this.statusBarItem.tooltip = '';
+      this.statusBarItem.tooltip = "";
       this.statusBarItem.hide();
     }
   },
@@ -494,7 +674,7 @@ const Kite = {
     this.getStatus(document).then(status => {
       this.lastStatus = status;
       this.setStatusBarLabel();
-    })
+    });
   },
 
   isGrammarSupported(e) {
@@ -502,34 +682,40 @@ const Kite = {
   },
 
   isDocumentGrammarSupported(d) {
-    return d &&
-           this.supportedLanguages.includes(d.languageId) &&
-           SUPPORTED_EXTENSIONS[d.languageId](d.fileName);
+    return (
+      d &&
+      this.supportedLanguages.includes(d.languageId) &&
+      SUPPORTED_EXTENSIONS[d.languageId](d.fileName)
+    );
   },
 
   documentForPath(path) {
-    return vscode.workspace.textDocuments.filter(d => d.fileName === path).shift();
+    return vscode.workspace.textDocuments
+      .filter(d => d.fileName === path)
+      .shift();
   },
 
   getStatus(document) {
-    if (!document) { return Promise.resolve({status: 'ready'}); }
+    if (!document) {
+      return Promise.resolve({ status: "ready" });
+    }
 
     const path = statusPath(document.fileName);
 
-    return KiteAPI.request({path})
-    .then(resp => {
-      if (resp.statusCode === 200) {
-        return promisifyReadResponse(resp).then(json => JSON.parse(json));
-      }
-    })
-    .catch(() => ({status: 'ready'}));
+    return KiteAPI.request({ path })
+      .then(resp => {
+        if (resp.statusCode === 200) {
+          return promisifyReadResponse(resp).then(json => JSON.parse(json));
+        }
+      })
+      .catch(() => ({ status: "ready" }));
   },
 
   getSupportedLanguages() {
     const path = languagesPath();
-    return this.request({path})
-    .then(json => JSON.parse(json))
-    .catch(() => ['python']);
+    return this.request({ path })
+      .then(json => JSON.parse(json))
+      .catch(() => ["python"]);
   },
 
   request(req, data) {
@@ -538,7 +724,7 @@ const Kite = {
 
   checkConnectivity() {
     return new Promise((resolve, reject) => {
-      require('dns').lookup('kite.com', (err) => {
+      require("dns").lookup("kite.com", err => {
         if (err && err.code == "ENOTFOUND") {
           reject();
         } else {
@@ -546,12 +732,18 @@ const Kite = {
         }
       });
     });
-  },
-}
+  }
+};
 
 module.exports = {
-  activate(ctx) { return Kite.activate(ctx); },
-  deactivate() { Kite.deactivate(); },
-  request(...args) { return Kite.request(...args); },
-  kite: Kite,
-}
+  activate(ctx) {
+    return Kite.activate(ctx);
+  },
+  deactivate() {
+    Kite.deactivate();
+  },
+  request(...args) {
+    return Kite.request(...args);
+  },
+  kite: Kite
+};

--- a/src/localconfig.js
+++ b/src/localconfig.js
@@ -1,31 +1,36 @@
-'use strict';
+"use strict";
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const {Logger} = require('kite-installer');
-const legacyConfigDir = path.join(os.homedir(), '.kite');
-const legacyConfigPath = path.join(legacyConfigDir, 'kite-config.json');
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const Logger = require("kite-connector/lib/logger");
+const legacyConfigDir = path.join(os.homedir(), ".kite");
+const legacyConfigPath = path.join(legacyConfigDir, "kite-config.json");
 
-const configDir = os.platform() === 'win32' 
-  ? path.join(process.env.LOCALAPPDATA, 'Kite')
-  : path.join(os.homedir(), '.kite');
+const configDir =
+  os.platform() === "win32"
+    ? path.join(process.env.LOCALAPPDATA, "Kite")
+    : path.join(os.homedir(), ".kite");
 
-const configPath = path.join(configDir, 'kite-vscode-config.json');
+const configPath = path.join(configDir, "kite-vscode-config.json");
 
 let config = null;
 
 try {
-  if(fs.existsSync(legacyConfigPath)) {
-    Logger.verbose(`initializing localconfig from legacy path ${legacyConfigPath}.`);
-    config = JSON.parse(fs.readFileSync(legacyConfigPath, {encoding: 'utf8'}));
+  if (fs.existsSync(legacyConfigPath)) {
+    Logger.verbose(
+      `initializing localconfig from legacy path ${legacyConfigPath}.`
+    );
+    config = JSON.parse(
+      fs.readFileSync(legacyConfigPath, { encoding: "utf8" })
+    );
     fs.unlinkSync(legacyConfigPath);
     if (fs.readdirSync(legacyConfigDir).length === 0) {
-      fs.rmdirSync(legacyConfigDir)
+      fs.rmdirSync(legacyConfigDir);
     }
   } else {
     Logger.verbose(`initializing localconfig from ${configPath}.`);
-    config = JSON.parse(fs.readFileSync(configPath, {encoding: 'utf8'}));
+    config = JSON.parse(fs.readFileSync(configPath, { encoding: "utf8" }));
   }
 } catch (err) {
   config = {};
@@ -33,8 +38,10 @@ try {
 
 function persist() {
   const str = JSON.stringify(config, null, 2); // serialize with whitespace for human readability
-  if (!fs.existsSync(configDir)) { fs.mkdirSync(configDir) }
-  fs.writeFile(configPath, str, 'utf8', (err) => {
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir);
+  }
+  fs.writeFile(configPath, str, "utf8", err => {
     if (err) {
       Logger.error(`failed to persist localconfig to ${configPath}`, err);
     }
@@ -49,10 +56,10 @@ function get(key, fallback) {
 // set assigns a value to storage and asynchronously persists it to disk
 function set(key, value) {
   config[key] = value;
-  persist();   // will write to disk asynchronously
+  persist(); // will write to disk asynchronously
 }
 
 module.exports = {
   get: get,
-  set: set,
+  set: set
 };

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -1,14 +1,14 @@
-'use strict';
+"use strict";
 
-const os = require('os');
-const vscode = require('vscode');
-const crypto = require('crypto');
-const {Logger} = require('kite-installer');
-const kitePkg = require('../package.json');
-const localconfig = require('./localconfig.js');
-const {metricsCounterPath} = require('./urls');
+const os = require("os");
+const vscode = require("vscode");
+const crypto = require("crypto");
+const Logger = require("kite-connector/lib/logger");
+const kitePkg = require("../package.json");
+const localconfig = require("./localconfig.js");
+const { metricsCounterPath } = require("./urls");
 
-const OS_VERSION = os.type() + ' ' + os.release();
+const OS_VERSION = os.type() + " " + os.release();
 
 const EDITOR_UUID = vscode.env.machineId;
 
@@ -16,30 +16,37 @@ let Kite;
 
 // Generate a unique ID for this user and save it for future use.
 function distinctID() {
-  var id = localconfig.get('distinctID');
+  var id = localconfig.get("distinctID");
   if (id === undefined) {
     // use the atom UUID
-    id = EDITOR_UUID || crypto.randomBytes(32).toString('hex');
-    localconfig.set('distinctID', id);
+    id = EDITOR_UUID || crypto.randomBytes(32).toString("hex");
+    localconfig.set("distinctID", id);
   }
   return id;
 }
 
 function sendFeatureMetric(name) {
-  if (process.env.NODE_ENV === 'test') { return; }
+  if (process.env.NODE_ENV === "test") {
+    return;
+  }
 
-  if (!Kite) { Kite = require('./kite'); }
+  if (!Kite) {
+    Kite = require("./kite");
+  }
   const path = metricsCounterPath();
 
-  Logger.debug('feature metric:', name);
+  Logger.debug("feature metric:", name);
 
-  return Kite.request({
-    path,
-    method: 'POST',
-  }, JSON.stringify({
-    name,
-    value: 1,
-  }));
+  return Kite.request(
+    {
+      path,
+      method: "POST"
+    },
+    JSON.stringify({
+      name,
+      value: 1
+    })
+  );
 }
 
 function featureRequested(name) {
@@ -52,10 +59,14 @@ function featureFulfilled(name) {
 
 function getOsName() {
   switch (os.platform()) {
-    case 'darwin': return 'macos';
-    case 'win32': return 'windows';
-    case 'linux': return 'linux';
-    default: return '';
+    case "darwin":
+      return "macos";
+    case "win32":
+      return "windows";
+    case "linux":
+      return "linux";
+    default:
+      return "";
   }
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,9 +1,9 @@
-'use strict';
+"use strict";
 
-const URL = require('url');
-const http = require('http');
-const {Logger} = require('kite-installer');
-const {head, last} = require('./utils');
+const URL = require("url");
+const http = require("http");
+const Logger = require("kite-connector/lib/logger");
+const { head, last } = require("./utils");
 
 module.exports = {
   routes: [],
@@ -12,31 +12,36 @@ module.exports = {
   },
 
   dispose() {
-    if (this.started) { this.stop(); }
+    if (this.started) {
+      this.stop();
+    }
   },
 
   start() {
-    if (this.started) { return; }
+    if (this.started) {
+      return;
+    }
 
     this.server = http.createServer((req, res) => {
-
       const url = URL.parse(req.url);
-      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader("Access-Control-Allow-Origin", "*");
       const handle = last(
-        head(this.routes.filter(r => r[0] === req.method && r[1] === url.pathname)) || []
+        head(
+          this.routes.filter(r => r[0] === req.method && r[1] === url.pathname)
+        ) || []
       );
       if (handle) {
         handle(req, res, url);
       } else {
-        res.writeHead(404, {'Content-Type': 'text/plain'});
-        res.end('Hello World');
+        res.writeHead(404, { "Content-Type": "text/plain" });
+        res.end("Hello World");
       }
     });
 
-    this.server.on('clientError', (err, socket) => {
-      socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
+    this.server.on("clientError", (err, socket) => {
+      socket.end("HTTP/1.1 400 Bad Request\r\n\r\n");
     });
-    
+
     this.server.listen(0, () => {
       this.PORT = this.server.address().port;
       this.started = true;
@@ -46,7 +51,7 @@ module.exports = {
 
   stop() {
     this.server.close(() => {
-      Logger.debug('Server closed');
-    })
+      Logger.debug("Server closed");
+    });
   }
 };

--- a/src/signature.js
+++ b/src/signature.js
@@ -1,11 +1,14 @@
-'use strict';
-const {SignatureHelp, SignatureInformation, ParameterInformation} = require('vscode');
-const {Logger} = require('kite-installer');
-const {MAX_FILE_SIZE} = require('./constants');
-const {parseJSON, stripTags, getFunctionDetails} = require('./utils');
-const {signaturePath, normalizeDriveLetter} = require('./urls');
-const {valueLabel, parameterType} = require('./data-utils');
-
+"use strict";
+const {
+  SignatureHelp,
+  SignatureInformation,
+  ParameterInformation
+} = require("vscode");
+const Logger = require("kite-connector/lib/logger");
+const { MAX_FILE_SIZE } = require("./constants");
+const { parseJSON, stripTags, getFunctionDetails } = require("./utils");
+const { signaturePath, normalizeDriveLetter } = require("./urls");
+const { valueLabel, parameterType } = require("./data-utils");
 
 module.exports = class KiteSignatureProvider {
   constructor(Kite, isTest) {
@@ -19,54 +22,62 @@ module.exports = class KiteSignatureProvider {
     const text = document.getText();
 
     if (text.length > MAX_FILE_SIZE) {
-      Logger.warn('buffer contents too large, not attempting signature');
+      Logger.warn("buffer contents too large, not attempting signature");
       return null;
     }
 
     const cursorPosition = document.offsetAt(position);
     const payload = {
       text,
-      editor: 'vscode',
+      editor: "vscode",
       filename: normalizeDriveLetter(document.fileName),
       cursor_runes: cursorPosition,
-      offset_encoding: 'utf-16'
+      offset_encoding: "utf-16"
     };
     Logger.debug(payload);
 
-    return this.Kite.request({
-      path: signaturePath(),
-      method: 'POST',
-    }, JSON.stringify(payload), document)
-    .then(data => {
-      data = parseJSON(data, {});
+    return this.Kite.request(
+      {
+        path: signaturePath(),
+        method: "POST"
+      },
+      JSON.stringify(payload),
+      document
+    )
+      .then(data => {
+        data = parseJSON(data, {});
 
-      const [call] = data.calls;
+        const [call] = data.calls;
 
-      const {callee} = call;
+        const { callee } = call;
 
-      const help = new SignatureHelp();
-      help.activeParameter = call.arg_index;
-      help.activeSignature = 0;
+        const help = new SignatureHelp();
+        help.activeParameter = call.arg_index;
+        help.activeSignature = 0;
 
-      const label = '⟠ ' + stripTags(valueLabel(callee));
-      const sig = new SignatureInformation(label);
-      const detail = getFunctionDetails(callee);
-      sig.parameters = (detail.parameters || []).map(p => {
-        const label = p.inferred_value
-          ? `${p.name}:${stripTags(parameterType(p))}`
-          : p.name
-        const param = new ParameterInformation(label);
-        return param;
-      });
+        const label = "⟠ " + stripTags(valueLabel(callee));
+        const sig = new SignatureInformation(label);
+        const detail = getFunctionDetails(callee);
+        sig.parameters = (detail.parameters || []).map(p => {
+          const label = p.inferred_value
+            ? `${p.name}:${stripTags(parameterType(p))}`
+            : p.name;
+          const param = new ParameterInformation(label);
+          return param;
+        });
 
-      if (Array.isArray(detail.return_value) && detail.return_value.length && detail.return_value[0].type) {
-        sig.documentation = `Returns → ${detail.return_value[0].type}`;
-      }
+        if (
+          Array.isArray(detail.return_value) &&
+          detail.return_value.length &&
+          detail.return_value[0].type
+        ) {
+          sig.documentation = `Returns → ${detail.return_value[0].type}`;
+        }
 
-      help.signatures = [sig];
+        help.signatures = [sig];
 
-      return help;
-    })
-    .catch(() => null);
+        return help;
+      })
+      .catch(() => null);
   }
-}
+};

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,29 +1,29 @@
-'use strict';
+"use strict";
 
-const path = require('path');
-const sinon = require('sinon');
-const {Logger} = require('kite-installer');
-const KiteAPI = require('kite-api');
-const {promisifyReadResponse} = require('../src/utils');
-const {withKiteRoutes} = require('kite-api/test/helpers/kite');
-const {fakeResponse} = require('kite-api/test/helpers/http');
+const path = require("path");
+const sinon = require("sinon");
+const Logger = require("kite-connector/lib/logger");
+const KiteAPI = require("kite-api");
+const { promisifyReadResponse } = require("../src/utils");
+const { withKiteRoutes } = require("kite-api/test/helpers/kite");
+const { fakeResponse } = require("kite-api/test/helpers/http");
 
 before(() => {
-  sinon.stub(Logger, 'log')
-})
+  sinon.stub(Logger, "log");
+});
 
 const Kite = {
   request(req, data) {
     return KiteAPI.request(req, data).then(resp => promisifyReadResponse(resp));
-  },
-}
+  }
+};
 
 function waitsFor(m, f, t, i) {
-  if (typeof m == 'function' && typeof f != 'function') {
+  if (typeof m == "function" && typeof f != "function") {
     i = t;
     t = f;
     f = m;
-    m = 'something to happen';
+    m = "something to happen";
   }
 
   const intervalTime = i || 10;
@@ -34,11 +34,14 @@ function waitsFor(m, f, t, i) {
       const res = f();
       if (res) {
         if (res.then) {
-          res.then(() => {
-            clearTimeout(timeout);
-            clearInterval(interval);
-            resolve();
-          }, (err) => {});
+          res.then(
+            () => {
+              clearTimeout(timeout);
+              clearInterval(interval);
+              resolve();
+            },
+            err => {}
+          );
         } else {
           clearTimeout(timeout);
           clearInterval(interval);
@@ -50,7 +53,7 @@ function waitsFor(m, f, t, i) {
     const timeout = setTimeout(() => {
       clearInterval(interval);
       let msg;
-      if (typeof m == 'function') {
+      if (typeof m == "function") {
         msg = `Waited ${timeoutDuration}ms for ${m()}`;
       } else {
         msg = `Waited ${timeoutDuration}ms for ${m} but nothing happened`;
@@ -62,11 +65,13 @@ function waitsFor(m, f, t, i) {
 
 function sleep(duration) {
   const t = new Date();
-  return waitsFor(`${duration}ms`, () => { return new Date() - t > duration; });
+  return waitsFor(`${duration}ms`, () => {
+    return new Date() - t > duration;
+  });
 }
 
 function delay(duration, block) {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     setTimeout(() => {
       block();
       resolve();
@@ -74,9 +79,8 @@ function delay(duration, block) {
   });
 }
 
-
-function fixtureURI (filepath) {
-  return path.resolve(__dirname, 'fixtures', filepath);
+function fixtureURI(filepath) {
+  return path.resolve(__dirname, "fixtures", filepath);
 }
 
 function log(v) {
@@ -84,11 +88,16 @@ function log(v) {
   return v;
 }
 
-function formatCall({method, path, payload}) {
-  return `${method} ${path} ${payload || ''}`;
+function formatCall({ method, path, payload }) {
+  return `${method} ${path} ${payload || ""}`;
 }
 
 module.exports = {
-  sleep, delay, fixtureURI, waitsFor,
-  Kite, log, formatCall,
+  sleep,
+  delay,
+  fixtureURI,
+  waitsFor,
+  Kite,
+  log,
+  formatCall
 };


### PR DESCRIPTION
Fix for extension failing to activate, due to Kite-Installer. 

Since we're only interested in the Logger object, and it's actually from Kite Connector, I removed it from `package.json` and changed 
`const {Logger} = require('kite-installer');` to 
`const Logger = require("kite-connector/lib/logger");` throughout the project.

Tested locally to ensure extension activates, and logging still works as expected.

