### PR TITLE
Improve status bar item colors

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,5 @@
+const vscode = require("vscode");
+
 const PYTHON_MODE = [
   { language: "python", scheme: "file" },
   { language: "python", scheme: "untitled" }
@@ -22,7 +24,14 @@ const ATTEMPTS = 30;
 
 const INTERVAL = 2500;
 
-const ERROR_COLOR = "#ff0000";
+const ERROR_COLOR = () => {
+  // For the High Contrast Theme, editorWarning.foreground renders the text invisible.
+  return vscode.workspace
+    .getConfiguration("workbench")
+    .colorTheme.includes("High Contrast")
+    ? "#ff0000"
+    : vscode.ThemeColor("editorWarning.foreground");
+};
 
 const WARNING_COLOR = "#929497";
 

--- a/src/kite.js
+++ b/src/kite.js
@@ -616,23 +616,23 @@ const Kite = {
         case KiteAPI.STATES.UNSUPPORTED:
           this.statusBarItem.tooltip =
             "Kite engine is currently not supported on your platform";
-          this.statusBarItem.color = ERROR_COLOR;
+          this.statusBarItem.color = ERROR_COLOR();
           this.statusBarItem.text = "𝕜𝕚𝕥𝕖: not supported";
           break;
         case KiteAPI.STATES.UNINSTALLED:
           this.statusBarItem.text = "𝕜𝕚𝕥𝕖: not installed";
           this.statusBarItem.tooltip = "Kite engine is not installed";
-          this.statusBarItem.color = ERROR_COLOR;
+          this.statusBarItem.color = ERROR_COLOR();
           break;
         case KiteAPI.STATES.INSTALLED:
           this.statusBarItem.text = "𝕜𝕚𝕥𝕖: not running";
           this.statusBarItem.tooltip = "Kite engine is not running";
-          this.statusBarItem.color = ERROR_COLOR;
+          this.statusBarItem.color = ERROR_COLOR();
           break;
         case KiteAPI.STATES.RUNNING:
           this.statusBarItem.text = "𝕜𝕚𝕥𝕖: not reachable";
           this.statusBarItem.tooltip = "Kite engine is not reachable";
-          this.statusBarItem.color = ERROR_COLOR;
+          this.statusBarItem.color = ERROR_COLOR();
           break;
         default:
           if (status) {


### PR DESCRIPTION
Fixes https://github.com/kiteco/kiteco/issues/8747

Edit:

I modified the status font color to be dark yellow (`editorWarning.foreground`). With that change, there is an edge case, where the "Default High Contrast" theme renders as black / not at all, so in those cases, I reuse the preeixsting Red font color.

Since the status bar background can change depending on the theme, hardcoding it to Red can result in undesirable contrasts.

By removing the hard coded values, if the theme is changed, the font color will update in concert with the rest of the status bar items.