### PR TITLE
Fix suggestions not being shown for snippet placeholders

### DIFF
--- a/src/completion.js
+++ b/src/completion.js
@@ -56,7 +56,11 @@ ${documentation_text}
 };
 
 const buildFilterText = (document, position) => {
-  const wordRange = document.getWordRangeAtPosition(position);
+  const selection =
+    window.activeTextEditor && window.activeTextEditor.selection;
+  const wordRange =
+    document.getWordRangeAtPosition(position) ||
+    (selection && new Range(selection.start, selection.end)); // Snippet placeholder selection range
   if (!wordRange) {
     return null;
   }


### PR DESCRIPTION
Fixes https://github.com/kiteco/kiteco/issues/8736

Previously, the way we constructed filterTexts did not handle snippet placeholders properly, resulting in the suggestion being filtered out.