### PR TITLE
fix VS code filtering

### DIFF
--- a/src/completion.js
+++ b/src/completion.js
@@ -77,13 +77,17 @@ const processCompletion = (
 ) => {
   const item = new CompletionItem(displayPrefix + c.display);
   item.insertText = c.snippet.text;
-  // Use previous word, otherwise default to c.snippet.text.
-  item.filterText = filterText ? filterText : c.snippet.text;
 
-  item.sortText = fill(String(i), numDigits, "0");
   const start = document.positionAt(c.replace.begin);
   const end = document.positionAt(c.replace.end);
-  item.range = new Range(start, end);
+  const replaceRange = new Range(start, end);
+  item.filterText = document.getText(replaceRange);
+
+  if (i === 0) {
+    item.preselect = true;
+  }
+  item.sortText = fill(String(i), numDigits, "\0");
+  item.range = replaceRange
   if (c.documentation.text !== "") {
     item.documentation = buildMarkdown(c.web_id, c.hint, c.documentation.text);
   }
@@ -110,7 +114,7 @@ const processCompletion = (
       offset += 5;
     }
     // Add closing tab stop
-    item.insertText += "$" + (i + 1).toString();
+    item.insertText += "$0";
     item.insertText = new SnippetString(item.insertText);
   }
   return item;

--- a/src/completion.js
+++ b/src/completion.js
@@ -73,7 +73,6 @@ const processCompletion = (
   displayPrefix,
   numDigits,
   i,
-  filterText
 ) => {
   const item = new CompletionItem(displayPrefix + c.display);
   item.insertText = c.snippet.text;
@@ -153,6 +152,7 @@ module.exports = class KiteCompletionProvider {
         end
       },
       no_snippets: !enableSnippets,
+      no_attribute_to_subscript: true,
       offset_encoding: OFFSET_ENCODING
     };
 
@@ -187,7 +187,6 @@ module.exports = class KiteCompletionProvider {
               "",
               numDigits,
               idx,
-              filterText
             )
           );
           const children = c.children || [];
@@ -200,7 +199,6 @@ module.exports = class KiteCompletionProvider {
                 "  ",
                 numDigits,
                 idx + offset,
-                filterText
               )
             );
             offset += 1;

--- a/src/kite.js
+++ b/src/kite.js
@@ -187,7 +187,9 @@ const Kite = {
         "(",
         "[",
         ",",
-        " "
+        " ",
+        "'",
+        "\"",
       )
     );
     this.disposables.push(


### PR DESCRIPTION
fixes kiteco/kiteco#9169

Based on my investigation, I've come to the conclusion that when a replacement range is specified, the `filterText` is compared with the text under the replacement range. A couple people in the depths of internet discussion seem to also have come to this conclusion.

Unfortunately [we don't have complete control over the sort order](https://github.com/kiteco/kiteco/issues/9049#issuecomment-548985916), so now that we see dict completions, this happens:

![Screen Shot 2019-11-01 at 4 50 56 PM](https://user-images.githubusercontent.com/1977419/68062481-db554200-fcc7-11e9-981b-a10cc17d4357.png)
![Screen Shot 2019-11-01 at 4 51 11 PM](https://user-images.githubusercontent.com/1977419/68062483-ddb79c00-fcc7-11e9-8adc-9a60589858d9.png)

As far as I can surmise, this is because VS Code's completion fuzzy matching algorithm considers the dict completion a "better match," so they end up at the top. This is particularly egregious in the latter case, since that key doesn't actually exist yet.

So there is a product question (@plungg @its-dhung) around whether we want to 
1. not show completions like `.f` -> `["foo"]
2. show them and accept the poor ordering
3. try to not show them where the dict key doesn't already exist, and accept the poor ordering otherwise
    * this is tricky, so I'd vote to go with option (1) or (2) for now, and create a separate issue for this if need be

Even if we want to do (1), I would argue that we should still merge this fix (since this is more correct), and handle filtering out the corresponding dict completions in `kited`.

cc @Moe-Kite 