### PR TITLE
Improved Support Logic

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,8 +1,11 @@
 const vscode = require("vscode");
 
-const DOCUMENT_SELECTOR = [
-  { language: "", scheme: "file" },
+const PYTHON_MODE = [
+  { language: "python", scheme: "file" },
+  { language: "python", scheme: "untitled" }
 ];
+
+const JAVASCRIPT_MODE = { language: "javascript", scheme: "file" };
 
 const SUPPORTED_EXTENSIONS = {
   python: fileName => /\.py$/.test(fileName),
@@ -39,7 +42,8 @@ const OFFSET_ENCODING = "utf-16";
 module.exports = {
   ATTEMPTS,
   INTERVAL,
-  DOCUMENT_SELECTOR,
+  PYTHON_MODE,
+  JAVASCRIPT_MODE,
   MAX_PAYLOAD_SIZE,
   MAX_FILE_SIZE,
   CONNECT_ERROR_LOCKOUT,

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,8 +1,23 @@
 const vscode = require("vscode");
 
-const SUPPORTED_DOCUMENTS = [
+const COMPLETIONS_SUPPORT = [
   { pattern: "**/*.{py,go}", scheme: "file" },
   { pattern: "**/*.{py,go}", scheme: "untitled" }
+];
+
+const DEFINITIONS_SUPPORT = [
+  { pattern: "**/*.{py}", scheme: "file" },
+  { pattern: "**/*.{py}", scheme: "untitled" }
+];
+
+const HOVER_SUPPORT = [
+  { pattern: "**/*.{py}", scheme: "file" },
+  { pattern: "**/*.{py}", scheme: "untitled" }
+];
+
+const SIGNATURES_SUPPORT = [
+  { pattern: "**/*.{py}", scheme: "file" },
+  { pattern: "**/*.{py}", scheme: "untitled" }
 ];
 
 const SUPPORTED_EXTENSIONS = {
@@ -40,7 +55,10 @@ const OFFSET_ENCODING = "utf-16";
 module.exports = {
   ATTEMPTS,
   INTERVAL,
-  SUPPORTED_DOCUMENTS,
+  COMPLETIONS_SUPPORT,
+  DEFINITIONS_SUPPORT,
+  HOVER_SUPPORT,
+  SIGNATURES_SUPPORT,
   MAX_PAYLOAD_SIZE,
   MAX_FILE_SIZE,
   CONNECT_ERROR_LOCKOUT,

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,11 @@
 const vscode = require("vscode");
 
+const EVENT_SUPPORT = (fileName) => {
+  const path = require("path");
+  const fileExt = path.extname(fileName);
+  return SUPPORTED_EXTENSIONS.includes(fileExt);
+}
+
 const COMPLETIONS_SUPPORT = [
   { pattern: "**/*.{py,go}", scheme: "file" },
   { pattern: "**/*.{py,go}", scheme: "untitled" }
@@ -20,10 +26,7 @@ const SIGNATURES_SUPPORT = [
   { pattern: "**/*.{py}", scheme: "untitled" }
 ];
 
-const SUPPORTED_EXTENSIONS = {
-  python: fileName => /\.py$/.test(fileName),
-  go: fileName => /\.go$/.test(fileName)
-};
+const SUPPORTED_EXTENSIONS = [".go", ".py"]
 
 // MAX_FILE_SIZE is the maximum file size to send to Kite
 const MAX_FILE_SIZE = 75 * Math.pow(2, 10); // 75 KB
@@ -55,6 +58,7 @@ const OFFSET_ENCODING = "utf-16";
 module.exports = {
   ATTEMPTS,
   INTERVAL,
+  EVENT_SUPPORT,
   COMPLETIONS_SUPPORT,
   DEFINITIONS_SUPPORT,
   HOVER_SUPPORT,

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,11 +1,9 @@
 const vscode = require("vscode");
 
-const PYTHON_MODE = [
-  { language: "python", scheme: "file" },
-  { language: "python", scheme: "untitled" }
+const SUPPORTED_DOCUMENTS = [
+  { pattern: "**/*.{py,go}", scheme: "file" },
+  { pattern: "**/*.{py,go}", scheme: "untitled" }
 ];
-
-const JAVASCRIPT_MODE = { language: "javascript", scheme: "file" };
 
 const SUPPORTED_EXTENSIONS = {
   python: fileName => /\.py$/.test(fileName),
@@ -42,8 +40,7 @@ const OFFSET_ENCODING = "utf-16";
 module.exports = {
   ATTEMPTS,
   INTERVAL,
-  PYTHON_MODE,
-  JAVASCRIPT_MODE,
+  SUPPORTED_DOCUMENTS,
   MAX_PAYLOAD_SIZE,
   MAX_FILE_SIZE,
   CONNECT_ERROR_LOCKOUT,

--- a/src/kite.js
+++ b/src/kite.js
@@ -6,7 +6,7 @@ const opn = require("opn");
 const KiteAPI = require("kite-api");
 const Logger = require("kite-connector/lib/logger");
 const {
-  DOCUMENT_SELECTOR,
+  PYTHON_MODE,
   ERROR_COLOR,
   SUPPORTED_EXTENSIONS
 } = require("./constants");
@@ -68,7 +68,7 @@ const Kite = {
 
     Logger.LEVEL =
       Logger.LEVELS[
-      vscode.workspace.getConfiguration("kite").loggingLevel.toUpperCase()
+        vscode.workspace.getConfiguration("kite").loggingLevel.toUpperCase()
       ];
 
     KiteAPI.isKiteInstalled().catch(err => {
@@ -95,19 +95,19 @@ const Kite = {
 
     this.disposables.push(
       vscode.languages.registerHoverProvider(
-        DOCUMENT_SELECTOR,
+        PYTHON_MODE,
         new KiteHoverProvider(Kite)
       )
     );
     this.disposables.push(
       vscode.languages.registerDefinitionProvider(
-        DOCUMENT_SELECTOR,
+        PYTHON_MODE,
         new KiteDefinitionProvider(Kite)
       )
     );
     this.disposables.push(
       vscode.languages.registerCompletionItemProvider(
-        DOCUMENT_SELECTOR,
+        PYTHON_MODE,
         new KiteCompletionProvider(Kite),
         "a",
         "b",
@@ -172,7 +172,7 @@ const Kite = {
     );
     this.disposables.push(
       vscode.languages.registerSignatureHelpProvider(
-        DOCUMENT_SELECTOR,
+        PYTHON_MODE,
         new KiteSignatureProvider(Kite),
         "(",
         ","
@@ -183,7 +183,7 @@ const Kite = {
       vscode.workspace.onDidChangeConfiguration(() => {
         Logger.LEVEL =
           Logger.LEVELS[
-          vscode.workspace.getConfiguration("kite").loggingLevel.toUpperCase()
+            vscode.workspace.getConfiguration("kite").loggingLevel.toUpperCase()
           ];
       })
     );

--- a/src/kite.js
+++ b/src/kite.js
@@ -7,7 +7,10 @@ const KiteAPI = require("kite-api");
 const Logger = require("kite-connector/lib/logger");
 const {
   ERROR_COLOR,
-  SUPPORTED_DOCUMENTS,
+  COMPLETIONS_SUPPORT,
+  DEFINITIONS_SUPPORT,
+  HOVER_SUPPORT,
+  SIGNATURES_SUPPORT,
   SUPPORTED_EXTENSIONS
 } = require("./constants");
 const KiteHoverProvider = require("./hover");
@@ -95,19 +98,19 @@ const Kite = {
 
     this.disposables.push(
       vscode.languages.registerHoverProvider(
-        SUPPORTED_DOCUMENTS,
+        HOVER_SUPPORT,
         new KiteHoverProvider(Kite)
       )
     );
     this.disposables.push(
       vscode.languages.registerDefinitionProvider(
-        SUPPORTED_DOCUMENTS,
+        DEFINITIONS_SUPPORT,
         new KiteDefinitionProvider(Kite)
       )
     );
     this.disposables.push(
       vscode.languages.registerCompletionItemProvider(
-        SUPPORTED_DOCUMENTS,
+        COMPLETIONS_SUPPORT,
         new KiteCompletionProvider(Kite),
         "a",
         "b",
@@ -172,7 +175,7 @@ const Kite = {
     );
     this.disposables.push(
       vscode.languages.registerSignatureHelpProvider(
-        SUPPORTED_DOCUMENTS,
+        SIGNATURES_SUPPORT,
         new KiteSignatureProvider(Kite),
         "(",
         ","

--- a/src/kite.js
+++ b/src/kite.js
@@ -6,8 +6,8 @@ const opn = require("opn");
 const KiteAPI = require("kite-api");
 const Logger = require("kite-connector/lib/logger");
 const {
-  PYTHON_MODE,
   ERROR_COLOR,
+  SUPPORTED_DOCUMENTS,
   SUPPORTED_EXTENSIONS
 } = require("./constants");
 const KiteHoverProvider = require("./hover");
@@ -68,7 +68,7 @@ const Kite = {
 
     Logger.LEVEL =
       Logger.LEVELS[
-        vscode.workspace.getConfiguration("kite").loggingLevel.toUpperCase()
+      vscode.workspace.getConfiguration("kite").loggingLevel.toUpperCase()
       ];
 
     KiteAPI.isKiteInstalled().catch(err => {
@@ -95,19 +95,19 @@ const Kite = {
 
     this.disposables.push(
       vscode.languages.registerHoverProvider(
-        PYTHON_MODE,
+        SUPPORTED_DOCUMENTS,
         new KiteHoverProvider(Kite)
       )
     );
     this.disposables.push(
       vscode.languages.registerDefinitionProvider(
-        PYTHON_MODE,
+        SUPPORTED_DOCUMENTS,
         new KiteDefinitionProvider(Kite)
       )
     );
     this.disposables.push(
       vscode.languages.registerCompletionItemProvider(
-        PYTHON_MODE,
+        SUPPORTED_DOCUMENTS,
         new KiteCompletionProvider(Kite),
         "a",
         "b",
@@ -172,7 +172,7 @@ const Kite = {
     );
     this.disposables.push(
       vscode.languages.registerSignatureHelpProvider(
-        PYTHON_MODE,
+        SUPPORTED_DOCUMENTS,
         new KiteSignatureProvider(Kite),
         "(",
         ","
@@ -183,7 +183,7 @@ const Kite = {
       vscode.workspace.onDidChangeConfiguration(() => {
         Logger.LEVEL =
           Logger.LEVELS[
-            vscode.workspace.getConfiguration("kite").loggingLevel.toUpperCase()
+          vscode.workspace.getConfiguration("kite").loggingLevel.toUpperCase()
           ];
       })
     );
@@ -227,7 +227,7 @@ const Kite = {
     this.disposables.push(
       vscode.window.onDidChangeVisibleTextEditors(editors => {
         editors.forEach(e => {
-          if (e.document.languageId === "python") {
+          if (e.document.languageId === "python", e.document.languageId === "go") {
             this.registerDocumentEvents(e.document);
             this.registerDocument(e.document);
           }
@@ -397,7 +397,7 @@ const Kite = {
 
     setTimeout(() => {
       vscode.window.visibleTextEditors.forEach(e => {
-        if (e.document.languageId === "python") {
+        if (e.document.languageId === "python" || e.document.languageId === "go") {
           this.registerEvents(e);
           this.registerEditor(e);
 
@@ -705,7 +705,7 @@ const Kite = {
     const path = languagesPath();
     return this.request({ path })
       .then(json => JSON.parse(json))
-      .catch(() => ["python"]);
+      .catch(() => ["python", "go"]);
   },
 
   request(req, data) {


### PR DESCRIPTION
Fixes https://github.com/kiteco/kiteco/issues/9574

Previously, the way we were enabling Kite for all languages resulted in no completions for non-Python and non-Go files.

This change constrains Kite functionality to Python and Go only, along with additional refactoring to help transition to the filetype support endpoint.

For QA, let's make sure they test

- All basic Kite functionality for python (completions, hover, etc.)
- Golang Kite completions
- non-Go or non-Python file IntelliSense competions (.css is one potential candidate)