### PR TITLE
Improve display of JS Beta Notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
             "type": "object",
             "title": "Kite Configuration",
             "properties": {
-                "kite.showJSBetaNotification": {
+                "kite.showJavascriptBetaNotification": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Whether or not to show the JS beta notification."
+                    "description": "Whether or not to show the JavaScript beta notification."
                 },
                 "kite.showGoBetaNotification": {
                     "type": "boolean",

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -33,8 +33,8 @@ const showGoBetaNotification = () => {
 };
 
 var hasSeenJSBetaNotification = false;
-const showJSBetaNotification = () => {
-    if (config.showJSBetaNotification &&
+const showJavascriptBetaNotification = () => {
+    if (config.showJavascriptBetaNotification &&
         !hasSeenJSBetaNotification) {
         vscode.window
             .showInformationMessage(
@@ -49,7 +49,7 @@ const showJSBetaNotification = () => {
                             kiteOpen("kite://home");
                             break;
                         case "Hide Forever":
-                            config.update("showJSBetaNotification", false, true);
+                            config.update("showJavascriptBetaNotification", false, true);
                             break;
                     }
                 }
@@ -66,7 +66,7 @@ const showNotification = (filename) => {
         case ".js":
         case ".jsx":
         case ".vue":
-            showJSBetaNotification();
+            showJavascriptBetaNotification();
             break;
     }
 };


### PR DESCRIPTION
Since the property key and description are user facing, use Javascript as opposed to JS. For reasons unknown, VSCode correctly renders `kite.showJavascriptBetaNotification` as "Show JavaScript Beta Notification".