### PR TITLE
Don't manually enumerate alphabet for trigger characters

### DIFF
--- a/src/completion.js
+++ b/src/completion.js
@@ -72,7 +72,7 @@ const processCompletion = (
   c,
   displayPrefix,
   numDigits,
-  i,
+  i
 ) => {
   const item = new CompletionItem(displayPrefix + c.display);
   item.insertText = c.snippet.text;

--- a/src/kite.js
+++ b/src/kite.js
@@ -110,10 +110,8 @@ const Kite = {
       )
     );
 
-    const lower = "abcdefghijklmnopqrstuvwxyz";
-    const upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     const special = ".([, '\\";
-    var completionsTriggers = (lower + upper + special).split("");
+    var completionsTriggers = special.split("");
 
     this.disposables.push(
       vscode.languages.registerCompletionItemProvider(


### PR DESCRIPTION
Resolves https://github.com/kiteco/kiteco/issues/10228

Only pass in special characters that VSCode doesn't trigger Kite for.