### PR TITLE
Update cached event TextEditor instance in registerEvents

### DIFF
--- a/src/kite.js
+++ b/src/kite.js
@@ -425,9 +425,14 @@ const Kite = {
   },
 
   registerEvents(e) {
-    if (e && e.document && !this.eventsByEditor.has(e.document.fileName)) {
-      const evt = new EditorEvents(this, e);
-      this.eventsByEditor.set(e.document.fileName, evt);
+    if (e && e.document) {
+      let evt = this.eventsByEditor.get(e.document.fileName);
+      if (evt && evt.editor) {
+        evt.editor = e;
+      } else {
+        evt = new EditorEvents(this, e);
+        this.eventsByEditor.set(e.document.fileName, evt);
+      }
     }
   },
 


### PR DESCRIPTION
Resolves https://github.com/kiteco/kiteco/issues/10138

Inspired by `registerEditor`, update cached `EditorEvents.editor` value when `registerEvents` is called. 
This allows selections to be updated accordingly, fixing autosearch when text editors are changed.