### PR TITLE
format multiline completions without adding extra whitespace

### DIFF
--- a/src/completion.js
+++ b/src/completion.js
@@ -81,6 +81,7 @@ const processCompletion = (
   const end = document.positionAt(c.replace.end);
   const replaceRange = new Range(start, end);
   item.filterText = document.getText(replaceRange);
+  item.keepWhitespace = true;
 
   if (i === 0) {
     item.preselect = true;


### PR DESCRIPTION
Fixes https://github.com/kiteco/kiteco/issues/10605

### What was done
Add `keepWhitespace` property to completion item to tell VSCode not to insert additional whitespace.

#### Before:
![multiline_before](https://user-images.githubusercontent.com/18232816/78737304-12c5bb80-7904-11ea-85cf-2c3239f738f1.gif)

#### After:
![desired_behavior?](https://user-images.githubusercontent.com/18232816/78737174-c5494e80-7903-11ea-9174-de6e6d5bb470.gif)
![multiline_tabs_vsc](https://user-images.githubusercontent.com/18232816/78737179-c7aba880-7903-11ea-9d11-9fc84f0622f1.gif)

### Considerations

Haven't yet been able to get a multiline Python completion to try this with. Open to more suggestions! Have tried:
```
import scrapy
class BookSpider(scrapy.Spider):
    name = $
```
Will look more into this tomorrow.
