### PR TITLE
VSCode Onboarding with Command Palette and for First-Time Users

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,20 @@
             {
                 "command": "kite.open-copilot",
                 "title": "Kite: Open Copilot"
+            },
+            {
+                "command": "kite.python-tutorial",
+                "title": "Kite: Python Tutorial"
+            },
+            {
+                "command": "kite.javascript-tutorial",
+                "title": "Kite: Javascript Tutorial"
+            },
+            {
+                "command": "kite.go-tutorial",
+                "title": "Kite: Go Tutorial"
             }
+
         ],
         "configuration": {
             "type": "object",

--- a/src/kite.js
+++ b/src/kite.js
@@ -283,6 +283,37 @@ const Kite = {
       )
     );
 
+    const openKiteTutorial = async language => {
+      try {
+        const path = await KiteAPI.getOnboardingFilePath("vscode", language)
+        const tutorial = await vscode.workspace.openTextDocument(path);
+        vscode.window.showTextDocument(tutorial);
+        KiteAPI.setKiteSetting("has_done_onboarding", true);
+      } catch(e) {
+        vscode.window.showErrorMessage(
+          "We were unable to open the tutorial. Try again later or email us at feedback@kite.com",
+        );
+      }
+    };
+
+    this.disposables.push(
+      vscode.commands.registerCommand("kite.python-tutorial", () => {
+        openKiteTutorial("python");
+      })
+    );
+
+    this.disposables.push(
+      vscode.commands.registerCommand("kite.javascript-tutorial", () => {
+        openKiteTutorial("javascript");
+      })
+    );
+
+    this.disposables.push(
+      vscode.commands.registerCommand("kite.go-tutorial", () => {
+        openKiteTutorial("go");
+      })
+    );
+
     this.disposables.push(
       vscode.commands.registerCommand("kite.help", () => {
         opn("https://help.kite.com/category/46-vs-code-integration");
@@ -351,6 +382,9 @@ const Kite = {
             }
           }
         });
+
+      KiteAPI.getKiteSetting("has_done_onboarding")
+        .then(hasDone => !hasDone && openKiteTutorial('python'));
     }
 
     setTimeout(() => {

--- a/src/kite.js
+++ b/src/kite.js
@@ -142,7 +142,7 @@ const Kite = {
     );
 
     vscode.window.activeTextEditor &&
-      showNotification(this, vscode.window.activeTextEditor.document.fileName);
+      showNotification(vscode.window.activeTextEditor.document.fileName);
 
     this.disposables.push(
       vscode.window.onDidChangeActiveTextEditor(e => {

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -4,7 +4,6 @@ const vscode = require("vscode");
 var path = require('path');
 
 const { kiteOpen } = require("./utils");
-const { settingsPath } = require("./urls")
 const config = vscode.workspace.getConfiguration("kite");
 
 var hasSeenGoBetaNotification = false;
@@ -33,52 +32,10 @@ const showGoBetaNotification = () => {
     }
 };
 
-const hideJSBetaNotificationKey = "hideJavascriptBetaNotification";
-var hasSeenJSBetaNotification = false;
-const showJavascriptBetaNotification = (kite) => {
-    if (kite.globalState.get(hideJSBetaNotificationKey, false) ||
-        hasSeenJSBetaNotification) {
-        return
-    }
-    kite.request({
-        path: settingsPath("kite_js_enabled"),
-        method: "GET"
-    }).then((isEnabled) => {
-        if (isEnabled !== "true") {
-            return
-        }
-
-        vscode.window
-            .showInformationMessage(
-                "Welcome to the Kite for JavaScript Beta! You\'ve got early access to our line-of-code completions for JavaScript, powered by machine learning. If you\'d like to disable the beta, you can do so in the Copilot.",
-                "Open Copilot",
-                "Hide Forever"
-            )
-            .then(item => {
-                if (item) {
-                    switch (item) {
-                        case "Open Copilot":
-                            kiteOpen("kite://home");
-                            break;
-                        case "Hide Forever":
-                            kite.globalState.update(hideJSBetaNotificationKey, true);
-                            break;
-                    }
-                }
-            });
-            hasSeenJSBetaNotification = true;
-    })
-};
-
-const showNotification = (kite, filename) => {
+const showNotification = (filename) => {
     switch (path.extname(filename)) {
         case ".go":
             showGoBetaNotification();
-            break;
-        case ".js":
-        case ".jsx":
-        case ".vue":
-            showJavascriptBetaNotification(kite);
             break;
     }
 };


### PR DESCRIPTION
Addresses VSCode for kiteco/kiteco#10456 for the updated spec.
Closes https://github.com/kiteco/kiteco/issues/10753

### What was done
Added `Kite: <lang> Tutorial` commands to the command palette and made it so first time users will have the python tutorial file automatically open. The Go and Javascript tutorial files don't yet exist so this change would at the moment create an error notification (see attached). ~Should test and merge after those files get added to the endpoint.~ Should merge for release at JS public launch.

#### Error Notification
I modeled the text off Atom's current notification. Let me know if you'd like something different @plungg 

##### Unexpanded
<img width="453" alt="Screen Shot 2020-04-24 at 7 41 48 PM" src="https://user-images.githubusercontent.com/18232816/80269591-f052d280-8665-11ea-9d65-c77fee8796fa.png">

##### Expanded
<img width="457" alt="Screen Shot 2020-04-24 at 7 42 04 PM" src="https://user-images.githubusercontent.com/18232816/80269590-ee890f00-8665-11ea-821f-1b2b6e828858.png">

### QA
Check that:

1. Opening VSCode with `kite.showWelcomeNotificationOnStartup: true` in vscode's preferences and `"has_done_onboarding": "false"` in `~/.kite/settings.json` attempts to open the Python onboarding file. (This seems a little flakey at the moment. I'm able to get this consistent if I stop all kite processes, `rm -rf ~/.kite`, start up Kite, then run the vscode extension debug environment.)
2. Commands for `Kite: Go Tutorial` and `Kite: Javascript Tutorial` are present in the command palette. (Note that these will fail to pull an onboarding file from kited at the moment as those files do not exist).
3. The above error notification comes up if the command is run and kited is not available (example case for any potential error in the chain).
4. The JavaScript beta notification does not appear when opening a js, vue, or jsx file (or at all).