### PR TITLE
Fix stale document

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -43,7 +43,7 @@ module.exports = class EditorEvents {
     this.timeout = setTimeout(() => this.mergeEvents(), 0);
     // was resulting in unhandled Promise rejection from `this.pendingPromiseReject(err)`
     // below... so we catch it
-    return this.pendingPromise.catch((err) => {});
+    return this.pendingPromise.catch(() => {});
   }
 
   reset() {
@@ -75,7 +75,7 @@ module.exports = class EditorEvents {
       promise = promise.then(() => this.Kite.request({
         path: '/clientapi/editor/event',
         method: 'POST',
-      }, JSON.stringify(this.buildEvent(focus, doc, editor.selection)), doc))
+      }, JSON.stringify(this.buildEvent(focus, doc, editor.selection)), doc));
     }
 
     return promise
@@ -88,12 +88,6 @@ module.exports = class EditorEvents {
     })
     .catch((err) => {
       this.pendingPromiseReject && this.pendingPromiseReject(err);
-      // on connection error send a metric, but not too often or we will generate too many events
-      // if (!this.lastErrorAt ||
-      //     secondsSince(this.lastErrorAt) >= CONNECT_ERROR_LOCKOUT) {
-      //   this.lastErrorAt = new Date();
-      //   // metrics.track('could not connect to event endpoint', err);
-      // }
     })
     .then(() => {
       delete this.pendingPromise;
@@ -131,9 +125,9 @@ module.exports = class EditorEvents {
       event.selections = [{
         start: document.offsetAt(selection.start),
         end: document.offsetAt(selection.end),
-      }]
+      }];
     }
 
     return event;
   }
-}
+};

--- a/src/events.js
+++ b/src/events.js
@@ -11,14 +11,12 @@ module.exports = class EditorEvents {
   constructor(Kite, editor) {
     this.Kite = Kite;
     this.editor = editor;
-    this.document = editor.document;
     this.reset();
   }
 
   dispose() {
     delete this.Kite;
     delete this.editor;
-    delete this.document;
   }
 
   focus() {
@@ -54,12 +52,12 @@ module.exports = class EditorEvents {
   }
 
   mergeEvents() {
-    if (!this.document || !this.editor) {
+    if (!this.editor || !this.editor.document) {
       return;
     }
 
-    const doc = this.document;
-    const editor= this.editor;
+    const editor = this.editor;
+    const doc = editor.document;
     let focus = this.pendingEvents.filter(e => e === 'focus')[0];
     let action = this.pendingEvents.some(e => e === 'edit') ? 'edit' : this.pendingEvents.pop();
 


### PR DESCRIPTION
### What was done

The document reference in `EditorEvents` sometimes sends the wrong buffer text to `/clientapi/editor/events`. This PR removes the `this.document` reference in favor of getting it from `this.editor.document`.

Original Buffer before some deletions (testing gibberish):
```
import scrapy

class MeokSpider:
    name = "hello"
    for
```

Incorrect `getText` after some deletions:
<img width="1613" alt="Screen Shot 2020-08-04 at 12 52 02 PM" src="https://user-images.githubusercontent.com/18232816/89338729-dc9a0d80-d651-11ea-988d-2a472101dc7e.png">
