### PR TITLE
add completion selected api

### DIFF
--- a/src/completion.js
+++ b/src/completion.js
@@ -124,7 +124,7 @@ const processCompletion = (
 
   item.command = {
     command: "kite.insert-completion",
-    arguments: [{lang: getSupportedLanguage(document)}]
+    arguments: [{lang: getSupportedLanguage(document), completion: {snippet: {text: c.snippet.text}}}]
   };
 
   return item;

--- a/src/kite.js
+++ b/src/kite.js
@@ -211,9 +211,10 @@ const Kite = {
     this.disposables.push(this.statusBarItem);
 
     this.disposables.push(
-      vscode.commands.registerCommand("kite.insert-completion", ({lang}) => {
+      vscode.commands.registerCommand("kite.insert-completion", ({lang, completion}) => {
         metrics.increment(`vscode_kite_${lang}_completions_inserted`);
         metrics.increment(`kite_${lang}_completions_inserted`);
+        metrics.sendCompletionSelected(lang, completion).catch(e => {console.error(e)});
       })
     );
 

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -7,7 +7,7 @@ const mixpanel = require("mixpanel");
 const Logger = require("kite-connector/lib/logger");
 const kitePkg = require("../package.json");
 const localconfig = require("./localconfig.js");
-const { metricsCounterPath } = require("./urls");
+const { metricsCounterPath, metricsCompletionSelectedPath} = require("./urls");
 
 const OS_VERSION = os.type() + " " + os.release();
 
@@ -30,6 +30,29 @@ function distinctID() {
     localconfig.set("distinctID", id);
   }
   return id;
+}
+
+function sendCompletionSelected(lang, completion) {
+  if (process.env.NODE_ENV === "test") {
+    return;
+  }
+
+  if (!Kite) {
+    Kite = require("./kite");
+  }
+  const path = metricsCompletionSelectedPath();
+
+  return Kite.request(
+      {
+        path,
+        method: "POST"
+      },
+      JSON.stringify({
+        editor: 'vscode',
+        language: lang,
+        completion: completion
+      })
+  );
 }
 
 function sendFeatureMetric(name) {
@@ -85,6 +108,7 @@ module.exports = {
   featureFulfilled,
   increment: name => sendFeatureMetric(name),
   getOsName,
+  sendCompletionSelected,
   version: kitePkg.version,
   track: (event, props) => {
     if (process.env.NODE_ENV !== "production") {

--- a/src/urls.js
+++ b/src/urls.js
@@ -7,6 +7,10 @@ function metricsCounterPath() {
   return '/clientapi/metrics/counters';
 }
 
+function metricsCompletionSelectedPath() {
+  return '/clientapi/metrics/completions/selected';
+}
+
 function languagesPath() {
   return '/clientapi/languages';
 }
@@ -158,6 +162,7 @@ module.exports = {
   languagesPath,
   membersPath,
   metricsCounterPath,
+  metricsCompletionSelectedPath,
   normalizeDriveLetter,
   openDocumentationInWebURL,
   openExampleInWebURL,


### PR DESCRIPTION
Fixes kiteco/kiteco#11696

This PR sends a POST to the `kited` completion-selected endpoint when the user selects a completion.