### PR TITLE
Replace path separator on windows.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -126,7 +126,10 @@ const escapeCommandArguments = (o) => {
   if(vscode.version < "1.30.0") {
     return JSON.stringify(o).replace(/"/g, '&quot;');
   }
-  return JSON.stringify(o)
+  if (os.platform()) == 'win32') {
+    return JSON.stringify(o).replace(/\\\\/g, "\/")
+  }
+    return JSON.stringify(o)
 }
 
 const kiteOpen = (url) => {


### PR DESCRIPTION
Fixes https://github.com/kiteco/kiteco/issues/11149

The hover `Def` link was broken on Windows, causing either the link text to be incorrect or the link to not work. It appears that the call to the VSCode command (`command:kite.def`) itself was incorrectly formatted such that the command was being called with the argument `undefined` rather than the expected args. Ultimately, the issue was that the filename needed a forward slash path-separator rather than the os-specific one. Replace `\\` with `/` fixes the link.

You can test on Windows by clicking the hover `Def` link and confirming that it works with this change.