### PR TITLE
status initializing for model warmup

### DIFF
--- a/src/kite.js
+++ b/src/kite.js
@@ -638,8 +638,8 @@ const Kite = {
         default:
           if (status) {
             this.statusBarItem.color = undefined
-            this.statusBarItem.text = "𝕜𝕚𝕥𝕖: " + status.short
-            this.statusBarItem.tooltip = status.long
+            this.statusBarItem.text = status.short ? ("𝕜𝕚𝕥𝕖: " + status.short) : "𝕜𝕚𝕥𝕖"
+            this.statusBarItem.tooltip = status.long ? status.long : ""
           } else {
             this._clearStatusBarItem()
           }

--- a/src/kite.js
+++ b/src/kite.js
@@ -650,6 +650,12 @@ const Kite = {
                 this.statusBarItem.tooltip =
                   "Kite engine is indexing your code";
                 break;
+              case "initializing":
+                this.statusBarItem.color = undefined;
+                this.statusBarItem.text = "𝕜𝕚𝕥𝕖: initializing";
+                this.statusBarItem.tooltip =
+                  "Kite engine is warming up";
+                break;
               case "syncing":
                 this.statusBarItem.text = "𝕜𝕚𝕥𝕖: syncing";
                 this.statusBarItem.color = undefined;

--- a/src/kite.js
+++ b/src/kite.js
@@ -641,18 +641,19 @@ const Kite = {
             this.statusBarItem.text = "𝕜𝕚𝕥𝕖: " + status.short
             this.statusBarItem.tooltip = status.long
           } else {
-            this.statusBarItem.text = "";
-            this.statusBarItem.color = undefined;
-            this.statusBarItem.tooltip = "";
-            this.statusBarItem.hide();
+            this._clearStatusBarItem()
           }
       }
     } else {
+      this._clearStatusBarItem()
+    }
+  },
+
+  _clearStatusBarItem() {
       this.statusBarItem.text = "";
       this.statusBarItem.color = undefined;
       this.statusBarItem.tooltip = "";
       this.statusBarItem.hide();
-    }
   },
 
   setStatus(state = this.lastState, document) {

--- a/src/kite.js
+++ b/src/kite.js
@@ -637,36 +637,9 @@ const Kite = {
           break;
         default:
           if (status) {
-            switch (status.status) {
-              case "noIndex":
-                this.statusBarItem.color = undefined;
-                this.statusBarItem.text = "𝕜𝕚𝕥𝕖: ready (unindexed)";
-                this.statusBarItem.tooltip =
-                  "Kite is ready, but no index available";
-                break;
-              case "indexing":
-                this.statusBarItem.color = undefined;
-                this.statusBarItem.text = "𝕜𝕚𝕥𝕖: indexing";
-                this.statusBarItem.tooltip =
-                  "Kite engine is indexing your code";
-                break;
-              case "initializing":
-                this.statusBarItem.color = undefined;
-                this.statusBarItem.text = "𝕜𝕚𝕥𝕖: initializing";
-                this.statusBarItem.tooltip =
-                  "Kite engine is warming up";
-                break;
-              case "syncing":
-                this.statusBarItem.text = "𝕜𝕚𝕥𝕖: syncing";
-                this.statusBarItem.color = undefined;
-                this.statusBarItem.tooltip = "Kite engine is syncing your code";
-                break;
-              case "ready":
-                this.statusBarItem.text = "𝕜𝕚𝕥𝕖";
-                this.statusBarItem.color = undefined;
-                this.statusBarItem.tooltip = "Kite is ready";
-                break;
-            }
+            this.statusBarItem.color = undefined
+            this.statusBarItem.text = "𝕜𝕚𝕥𝕖: " + status.short
+            this.statusBarItem.tooltip = status.long
           } else {
             this.statusBarItem.text = "";
             this.statusBarItem.color = undefined;


### PR DESCRIPTION
addresses https://github.com/kiteco/kiteco/issues/11798 for vscode
merge after https://github.com/kiteco/kiteco/pull/11804

<img width="591" alt="Screen Shot 2020-09-30 at 4 21 32 PM" src="https://user-images.githubusercontent.com/18232816/94751718-0d3eb080-033e-11eb-9f5b-f992ec3f88f4.png">

The current default status poll-time seems to be 5 seconds. From ML, models probably take ~15 seconds to warm up. Should we decrease the poll time, or is this fine? 