### PR TITLE
fix: .tsx typescript -> typescriptreact

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,12 @@
           "Typescript"
         ],
         "extensions": [
-          ".ts",
+          ".ts"
+        ]
+      },
+      {
+        "id": "typescriptreact",
+        "extensions": [
           ".tsx"
         ]
       }


### PR DESCRIPTION
Fixes https://github.com/kiteco/issue-tracker/issues/426 (sort of?)

### Verification (Eng)

I was able to reproduce the linked issue specifically with CRA (but not with other tsx files...), but it's somewhat hard to reproduce that this fixes it (can someone sanity check this?). 

This is what worked for me:

1) Follow the issue instructions to reproduce the issue, ie
```
npx create-react-app cra-demo-ts --template typescript
code cra-demo-ts
```
and open `src/App.tsx`.

2) Check the 'status bar' area for the filetype, which should be 'typescript' if you're able to immediately reproduce the issue. (If not, you might be able to click the filetype, bringing up a command menu to `Auto Detect`, then restart VSCode).
3) Launch the extension from the 'Run' tab
4) Open the same file in the file extension host
5) Click the filetype on the bottom and then "Auto Detect" in the command menu that pops up
6) Restart VSCode completely
7) The filetype should now be 'Typescript React' on the status bar and the issue resolved

Manually switching the file association and restarting VSCode doesn't seem to fix this. The status bar and what's shown in the `Configure File Association for '.tsx'` submenu seems out of sync (upstream bug?)

If the process is this manual, I'm not sure it would automatically fix for affected users.

### Considerations

I haven't actually looked into why this is an issue / what is the 'right thing' to do to avoid these kinds of conflicts, so issues like this and https://github.com/kiteco/kiteco/issues/11904 may still come up. It's a little surprising that our plugin definitions can affect linting and syntax highlighting when we have nothing to do with either. It might be worth looking into whether we're implementing [Contribution Points](https://code.visualstudio.com/api/references/contribution-points#contributes.languages) correctly (if multiple plugins associate the same extension with different `lanugageIDs`, what happens?) or whether this is a limitation of VSCode's extension manifest model.

This questions whether we should also have `.jsx` map to `javascriptreact`, but I cannot reproduce this with the plain `jsx` version of CRA 🤔 .