### PR TITLE
Find Related Code (experimental)

### DIFF
--- a/package.json
+++ b/package.json
@@ -332,7 +332,7 @@
     "atob": "^2.1.2",
     "formidable": "^1.1.1",
     "getmac": "^1.2.1",
-    "kite-api": "=3.15.0",
+    "kite-api": "=3.16.0",
     "kite-connector": "=3.12.0",
     "mixpanel": "^0.5.0",
     "md5": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -240,11 +240,11 @@
       },
       {
         "command": "kite.related-code-from-file",
-        "title": "Kite: Find Related Code From File"
+        "title": "Kite: Find Related Code From File (experimental)"
       },
       {
         "command": "kite.related-code-from-line",
-        "title": "Kite: Find Related Code From Line"
+        "title": "Kite: Find Related Code From Line (experimental)"
       },
       {
         "command": "kite.python-tutorial",
@@ -263,8 +263,7 @@
       "editor/context": [
         {
           "when": "editorHasSelection",
-          "command": "kite.related-code-from-line",
-          "group": "navigation"
+          "command": "kite.related-code-from-line"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -332,7 +332,7 @@
     "atob": "^2.1.2",
     "formidable": "^1.1.1",
     "getmac": "^1.2.1",
-    "kite-api": "=3.14.0",
+    "kite-api": "=3.15.0",
     "kite-connector": "=3.12.0",
     "mixpanel": "^0.5.0",
     "md5": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -272,11 +272,6 @@
       "type": "object",
       "title": "Kite Configuration",
       "properties": {
-        "kite.showGoBetaNotification": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether or not to show the Go beta notification."
-        },
         "kite.showWelcomeNotificationOnStartup": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -239,8 +239,12 @@
         "title": "Kite: Open Copilot"
       },
       {
-        "command": "kite.related-files",
-        "title": "Kite: Find related files (Experimental)"
+        "command": "kite.related-code-from-file",
+        "title": "Kite: Find Related Code From File"
+      },
+      {
+        "command": "kite.related-code-from-line",
+        "title": "Kite: Find Related Code From Line"
       },
       {
         "command": "kite.python-tutorial",
@@ -258,7 +262,9 @@
     "menus": {
       "editor/context": [
         {
-          "command": "kite.related-files"
+          "when": "editorHasSelection",
+          "command": "kite.related-code-from-line",
+          "group": "navigation"
         }
       ]
     },

--- a/src/kite.js
+++ b/src/kite.js
@@ -218,7 +218,7 @@ const Kite = {
       vscode.commands.registerTextEditorCommand("kite.related-code-from-file", (textEditor) => {
         KiteAPI
           .requestRelatedCode(textEditor.document.fileName, null, null, "vscode")
-          .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName))
+          .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName, 0))
       })
     );
 
@@ -226,9 +226,21 @@ const Kite = {
       vscode.commands.registerTextEditorCommand("kite.related-code-from-line", (textEditor) => {
         const zeroBasedLineNo = textEditor.selection.active.line
         const oneBasedLineNo = zeroBasedLineNo+1
-        KiteAPI
-          .requestRelatedCode(textEditor.document.fileName, oneBasedLineNo, null, "vscode")
-          .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName))
+
+        const requireNonEmptyLine = new Promise((resolve, reject) => {
+          if (textEditor.document.lineAt(zeroBasedLineNo).text === "") {
+            return reject({
+              data: {
+                responseData: "ErrEmptyLine"
+              }
+            })
+          }
+          return resolve()
+        })
+
+        requireNonEmptyLine
+          .then(() => KiteAPI.requestRelatedCode(textEditor.document.fileName, oneBasedLineNo, null, "vscode"))
+          .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName, oneBasedLineNo))
       })
     );
 

--- a/src/kite.js
+++ b/src/kite.js
@@ -231,8 +231,22 @@ const Kite = {
     );
 
     this.disposables.push(
-      vscode.commands.registerTextEditorCommand("kite.related-files", (textEditor) => {
-        opn(`http://localhost:46624/codenav/related/${encodeURIComponent(textEditor.document.fileName)}`);
+      vscode.commands.registerTextEditorCommand("kite.related-code-from-file", (textEditor) => {
+        KiteAPI
+          .requestRelatedCode(textEditor.document.fileName, null, null, "vscode")
+          .then(console.log)
+          .catch(console.log)
+      })
+    );
+
+    this.disposables.push(
+      vscode.commands.registerTextEditorCommand("kite.related-code-from-line", (textEditor) => {
+        console.log("0-based: ", textEditor.selection.active.line)
+        const oneBasedLineNo = textEditor.selection.active.line+1
+        KiteAPI
+          .requestRelatedCode(textEditor.document.fileName, oneBasedLineNo, null, "vscode")
+          .then(console.log)
+          .catch(console.log)
       })
     );
 

--- a/src/kite.js
+++ b/src/kite.js
@@ -218,19 +218,17 @@ const Kite = {
       vscode.commands.registerTextEditorCommand("kite.related-code-from-file", (textEditor) => {
         KiteAPI
           .requestRelatedCode(textEditor.document.fileName, null, null, "vscode")
-          .then(console.log)
-          .catch(console.log)
+          .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName))
       })
     );
 
     this.disposables.push(
       vscode.commands.registerTextEditorCommand("kite.related-code-from-line", (textEditor) => {
-        console.log("0-based: ", textEditor.selection.active.line)
-        const oneBasedLineNo = textEditor.selection.active.line+1
+        const zeroBasedLineNo = textEditor.selection.active.line
+        const oneBasedLineNo = zeroBasedLineNo+1
         KiteAPI
           .requestRelatedCode(textEditor.document.fileName, oneBasedLineNo, null, "vscode")
-          .then(console.log)
-          .catch(console.log)
+          .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName))
       })
     );
 

--- a/src/kite.js
+++ b/src/kite.js
@@ -217,7 +217,7 @@ const Kite = {
     this.disposables.push(
       vscode.commands.registerTextEditorCommand("kite.related-code-from-file", (textEditor) => {
         KiteAPI
-          .requestRelatedCode(textEditor.document.fileName, null, null, "vscode")
+          .requestRelatedCode("vscode", textEditor.document.fileName, null, null)
           .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName, 0))
       })
     );
@@ -239,7 +239,7 @@ const Kite = {
         })
 
         requireNonEmptyLine
-          .then(() => KiteAPI.requestRelatedCode(textEditor.document.fileName, oneBasedLineNo, null, "vscode"))
+          .then(() => KiteAPI.requestRelatedCode("vscode", textEditor.document.fileName, oneBasedLineNo, null))
           .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName, oneBasedLineNo))
       })
     );

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -21,7 +21,7 @@ module.exports = class NotificationsManager {
     }
   }
 
-  static getRelatedCodeErrHandler(filename) {
+  static getRelatedCodeErrHandler(filename, lineNo) {
     return (err) => {
       if (!err) {
         return;
@@ -50,6 +50,9 @@ module.exports = class NotificationsManager {
             vscode.window.showWarningMessage(
               "Kite is not done indexing your project yet. Please wait for the status icon to switch to ready before using Code Finder."
             );
+            return;
+          case "ErrEmptyLine":
+            vscode.window.showWarningMessage(`Line ${lineNo} in file ${filename} is empty. Code finder only works in non-empty lines.`);
             return;
         }
       }

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -1,0 +1,63 @@
+const vscode = require("vscode");
+const opn = require("opn");
+const metrics = require("./metrics");
+
+const KiteAPI = require("kite-api");
+
+module.exports = class NotificationsManager {
+  constructor() {
+    this.shownNotifications = {};
+  }
+
+  showErrorMessage(message, ...actions) {
+    if (!this.shownNotifications[message]) {
+      this.shownNotifications[message] = true;
+      return vscode.window.showErrorMessage(message, ...actions).then(item => {
+        delete this.shownNotifications[message];
+        return item;
+      });
+    } else {
+      return Promise.resolve();
+    }
+  }
+
+  static showWelcomeNotification(config, openKiteTutorial) {
+    vscode.window
+      .showInformationMessage(
+        "Welcome to Kite for VS Code",
+        "Learn how to use Kite",
+        "Don't show this again"
+      )
+      .then(item => {
+        switch (item) {
+          case "Learn how to use Kite":
+            opn("http://help.kite.com/category/46-vs-code-integration");
+            break;
+          case "Don't show this again":
+            config.update("showWelcomeNotificationOnStartup", false, true);
+            break;
+        }
+      });
+    KiteAPI.getKiteSetting("has_done_onboarding")
+      .then(hasDone => !hasDone && openKiteTutorial('python'));
+  }
+
+  static showKiteInstallNotification(err) {
+    if (typeof err.data !== 'undefined' && err.data.state === KiteAPI.STATES.UNINSTALLED) {
+      metrics.track("vscode_kite_installer_notification_shown");
+      vscode.window
+        .showInformationMessage(
+          "Kite requires the Kite Engine backend to provide completions and documentation. Please install it to use Kite.",
+          "Install"
+        )
+        .then(item => {
+          switch (item) {
+            case "Install":
+              opn("https://www.kite.com/install/?utm_medium=editor&utm_source=vscode");
+              metrics.track("vscode_kite_installer_github_link_clicked");
+              break;
+          }
+        });
+    }
+  }
+};


### PR DESCRIPTION
Addresses https://github.com/kiteco/kiteco/issues/11900 for vscode

Should we do non-empty line checks in-editor or in kited? I figure we don't have to open large files or handle any of that if we do it in-editor, though this means each editor ends up with their own implementation. It turns out to be easy in VSCode, unsure about other editors.

Not handled:
1. ErrPathReadNotPermitted (unsure what to tell the user to do)
2. ErrProjectNotLoaded (no editor events happened before the request, highly unlikely to ever occur)
3. ErrProjectBuildFailed (I think this is only if `Terminate()` is called in kited?)