### PR TITLE
change: use .catch().then() instead of .catch().finally()

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -83,7 +83,7 @@ module.exports = class EditorEvents {
       .catch((err) => {
         this.pendingPromiseReject && this.pendingPromiseReject(err);
       })
-      .finally(() => {
+      .then(() => {
         delete this.pendingPromise;
         delete this.pendingPromiseResolve;
         delete this.pendingPromiseReject;


### PR DESCRIPTION
I'm guessing the rollbars are due to the same issue as in Atom.