### PR TITLE
Support Python .pyw extension.

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,8 @@
           "python"
         ],
         "extensions": [
-          ".py"
+          ".py",
+          ".pyw"
         ]
       },
       {

--- a/src/constants.js
+++ b/src/constants.js
@@ -31,7 +31,7 @@ function IsEnabledAndSupported(fileName) {
 function CompletionsSupport() {
   // Python has "FullCompletionsSupport" so filter from regular.
   const enabled = EnabledAndSupported()
-                  .filter(ext => ext != ".py")
+                  .filter(ext => ext != ".py" && ext != ".pyw")
                   .join(',');
   if (enabled === "") {
     return [];
@@ -53,29 +53,29 @@ function requirePythonEnabled(fn) {
 
 function FullCompletionsSupport() {
   return [
-    { pattern: "**/*.{py}", scheme: "file" },
-    { pattern: "**/*.{py}", scheme: "untitled" }
+    { pattern: "**/*.{py,pyw}", scheme: "file" },
+    { pattern: "**/*.{py,pyw}", scheme: "untitled" }
   ];
 }
 
 function DefinitionsSupport() {
   return [
-    { pattern: "**/*.{py}", scheme: "file" },
-    { pattern: "**/*.{py}", scheme: "untitled" }
+    { pattern: "**/*.{py,pyw}", scheme: "file" },
+    { pattern: "**/*.{py,pyw}", scheme: "untitled" }
   ];
 }
 
 function HoverSupport() {
   return [
-    { pattern: "**/*.{py}", scheme: "file" },
-    { pattern: "**/*.{py}", scheme: "untitled" }
+    { pattern: "**/*.{py,pyw}", scheme: "file" },
+    { pattern: "**/*.{py,pyw}", scheme: "untitled" }
   ];
 }
 
 function SignaturesSupport() {
   return [
-    { pattern: "**/*.{py}", scheme: "file" },
-    { pattern: "**/*.{py}", scheme: "untitled" }
+    { pattern: "**/*.{py,pyw}", scheme: "file" },
+    { pattern: "**/*.{py,pyw}", scheme: "untitled" }
   ];
 }
 
@@ -98,6 +98,7 @@ function SupportedExtensions() {
     ".m",
     ".php",
     ".py",
+    ".pyw",
     ".rb",
     ".scala",
     ".sh",

--- a/src/utils.js
+++ b/src/utils.js
@@ -165,6 +165,7 @@ const extToLangMap = new Map([
   ["m","objectivec"],
   ["php", "php"],
   ["py", "python"],
+  ["pyw", "python"],
   ["rb","ruby"],
   ["scala","scala"],
   ["sh","bash"],


### PR DESCRIPTION
This PR adds the necessary changes for the VSCode plugin to support `.pyw` files (see https://github.com/kiteco/kiteco/pull/12167). I've tested this locally and everything seems to work normally.