### PR TITLE
Handle ErrPathHasUnsupportedExtension

### DIFF
--- a/src/kite.js
+++ b/src/kite.js
@@ -218,7 +218,7 @@ export const Kite = {
       vscode.commands.registerTextEditorCommand("kite.related-code-from-file", (textEditor) => {
         KiteAPI
           .requestRelatedCode("vscode", vscode.env.appRoot, textEditor.document.fileName)
-          .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName, 0, textEditor.document.fileName));
+          .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName, 0));
       })
     );
 
@@ -240,7 +240,7 @@ export const Kite = {
 
         requireNonEmptyLine
           .then(() => KiteAPI.requestRelatedCode("vscode", vscode.env.appRoot, textEditor.document.fileName, oneBasedLineNo))
-          .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName, oneBasedLineNo, textEditor.document.fileName));
+          .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName, oneBasedLineNo));
       })
     );
 

--- a/src/kite.js
+++ b/src/kite.js
@@ -218,7 +218,7 @@ export const Kite = {
       vscode.commands.registerTextEditorCommand("kite.related-code-from-file", (textEditor) => {
         KiteAPI
           .requestRelatedCode("vscode", vscode.env.appRoot, textEditor.document.fileName)
-          .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName, 0));
+          .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName, 0, textEditor.document.fileName));
       })
     );
 
@@ -240,7 +240,7 @@ export const Kite = {
 
         requireNonEmptyLine
           .then(() => KiteAPI.requestRelatedCode("vscode", vscode.env.appRoot, textEditor.document.fileName, oneBasedLineNo))
-          .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName, oneBasedLineNo));
+          .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName, oneBasedLineNo, textEditor.document.fileName));
       })
     );
 

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -1,5 +1,6 @@
 import vscode from "vscode";
 import open from "open";
+import path from "path";
 
 import metrics from "./metrics";
 
@@ -22,7 +23,7 @@ export default class NotificationsManager {
     }
   }
 
-  static getRelatedCodeErrHandler(filename, lineNo) {
+  static getRelatedCodeErrHandler(filename, lineNo, fileName) {
     return (err) => {
       if (!err) {
         return;
@@ -55,6 +56,11 @@ export default class NotificationsManager {
           case "ErrEmptyLine":
             vscode.window.showWarningMessage(`Line ${lineNo} in file ${filename} is empty. Code finder only works in non-empty lines.`);
             return;
+          case "ErrPathHasUnsupportedExtension": {
+            const fileExt = path.extname(fileName);
+            vscode.window.showWarningMessage(`Code Finder does not support the \`${fileExt}\` file extension yet.`);
+            return;
+          }
         }
       }
 

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -45,6 +45,9 @@ export default class NotificationsManager {
 
       if (responseData && typeof responseData === 'string') {
         switch (responseData.trim()) {
+          case "ErrPathHasUnsupportedExtension":
+            vscode.window.showWarningMessage(`Code Finder does not support the \`${path.extname(filename)}\` file extension yet.`);
+            return;
           case "ErrPathNotInSupportedProject":
             vscode.window.showWarningMessage(`The file ${filename} is not in any Git project. Code finder only works inside Git projects.`);
             return;
@@ -56,10 +59,6 @@ export default class NotificationsManager {
           case "ErrEmptyLine":
             vscode.window.showWarningMessage(`Line ${lineNo} in file ${filename} is empty. Code finder only works in non-empty lines.`);
             return;
-          case "ErrPathHasUnsupportedExtension": {
-            vscode.window.showWarningMessage(`Code Finder does not support the \`${path.extname(filename)}\` file extension yet.`);
-            return;
-          }
         }
       }
 

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -23,7 +23,7 @@ export default class NotificationsManager {
     }
   }
 
-  static getRelatedCodeErrHandler(filename, lineNo, fileName) {
+  static getRelatedCodeErrHandler(filename, lineNo) {
     return (err) => {
       if (!err) {
         return;
@@ -57,8 +57,7 @@ export default class NotificationsManager {
             vscode.window.showWarningMessage(`Line ${lineNo} in file ${filename} is empty. Code finder only works in non-empty lines.`);
             return;
           case "ErrPathHasUnsupportedExtension": {
-            const fileExt = path.extname(fileName);
-            vscode.window.showWarningMessage(`Code Finder does not support the \`${fileExt}\` file extension yet.`);
+            vscode.window.showWarningMessage(`Code Finder does not support the \`${path.extname(filename)}\` file extension yet.`);
             return;
           }
         }


### PR DESCRIPTION
<img width="458" alt="Screen Shot 2020-12-08 at 5 28 19 PM" src="https://user-images.githubusercontent.com/47993402/101561885-02764c80-397b-11eb-9111-e41b8ccf1d32.png">

VSCode implementation of https://github.com/kiteco/kiteco/issues/12098.

Unfortunately, it looks like Markdown is not supported in notifications anymore, so the filename is wrapped in "``" instead. https://github.com/Microsoft/vscode/issues/50512