### PR TITLE
Remove empty line checks

### DIFF
--- a/src/kite.js
+++ b/src/kite.js
@@ -222,7 +222,7 @@ export const Kite = {
       vscode.commands.registerTextEditorCommand("kite.related-code-from-file", (textEditor) => {
         KiteAPI
           .requestRelatedCode("vscode", vscode.env.appRoot, textEditor.document.fileName)
-          .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName, 0));
+          .catch(NotificationsManager.getRelatedCodeErrHandler());
       })
     );
 
@@ -230,20 +230,8 @@ export const Kite = {
       vscode.commands.registerTextEditorCommand("kite.related-code-from-line", (textEditor) => {
         const zeroBasedLineNo = textEditor.selection.active.line;
         const oneBasedLineNo = zeroBasedLineNo+1;
-
-        const requireNonEmptyLine = new Promise((resolve, reject) => {
-          if (textEditor.document.lineAt(zeroBasedLineNo).text === "") {
-            return reject({
-              data: {
-                responseData: "ErrEmptyLine"
-              }
-            });
-          }
-          return resolve();
-        });
-
-        requireNonEmptyLine
-          .then(() => KiteAPI.requestRelatedCode("vscode", vscode.env.appRoot, textEditor.document.fileName, oneBasedLineNo))
+        KiteAPI
+          .requestRelatedCode("vscode", vscode.env.appRoot, textEditor.document.fileName, oneBasedLineNo)
           .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName, oneBasedLineNo));
       })
     );

--- a/src/kite.js
+++ b/src/kite.js
@@ -232,7 +232,7 @@ export const Kite = {
         const oneBasedLineNo = zeroBasedLineNo+1;
         KiteAPI
           .requestRelatedCode("vscode", vscode.env.appRoot, textEditor.document.fileName, oneBasedLineNo)
-          .catch(NotificationsManager.getRelatedCodeErrHandler(textEditor.document.fileName, oneBasedLineNo));
+          .catch(NotificationsManager.getRelatedCodeErrHandler());
       })
     );
 

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -23,7 +23,7 @@ export default class NotificationsManager {
     }
   }
 
-  static getRelatedCodeErrHandler(filename, lineNo) {
+  static getRelatedCodeErrHandler() {
     return (err) => {
       if (!err) {
         return;


### PR DESCRIPTION
VSCode portion of https://github.com/kiteco/kiteco/issues/12248

Remove empty line rejections. Also remove unused args in `getRelatedCodeErrHandler`.