### PR TITLE
VS Code Build Issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.135.0",
   "publisher": "kiteco",
   "engines": {
-    "vscode": "^1.32.0"
+    "vscode": "^1.34.0"
   },
   "icon": "logo.png",
   "galleryBanner": {

--- a/package.json
+++ b/package.json
@@ -374,6 +374,7 @@
   },
   "devDependencies": {
     "@atom/temp": "^0.8.4",
+    "@babel/runtime": "^7.12.5",
     "@types/chai": "^4.2.14",
     "@types/md5": "^2.2.1",
     "@types/mixpanel": "^2.14.2",


### PR DESCRIPTION
When I tried to run the VS Code debugger, this error was emitted:
```
[webpack-cli] Error: Cannot find module '@babel/runtime/helpers/interopRequireDefault'
```

Via [Stackoverflow](https://stackoverflow.com/questions/52486219/unable-to-resolve-module-babel-runtime-helpers-interoprequiredefault), adding @babel/runtime resolves the issue for me.

Running `npm install-local` resulted in:
```
@types/vscode ^1.34.0 greater than engines.vscode ^1.32.0. Consider upgrade engines.vscode or use an older @types/vscode version
```
so I also updated the `engines.vscode` version.