### PR TITLE
Fix handling of $ characters in a snippet text

### DIFF
--- a/src/completion.js
+++ b/src/completion.js
@@ -118,8 +118,8 @@ const processCompletion = (
         snippetText.slice(placeholder.end);
       offset += 5;
     }
-    // Sanitize snippet text by replacing all $ not for placeholders with \\$
-    snippetText = snippetText.replaceAll(/\$(?!{)/g, "\\$");
+    // Sanitize snippet text by replacing all $ with \\$ except those in the form of ${x:...}
+    snippetText = snippetText.replaceAll(/\$(?!{\d+:.*})/g, "\\$");
     // Add closing tab stop
     snippetText += "$0";
     item.insertText = new SnippetString(snippetText);


### PR DESCRIPTION
Closes https://github.com/kiteco/issue-tracker/issues/761

VS Code requires any `$` characters in a snippet to be replaced with `\\$`. Since we insert `${...` to denote a placeholder, we replace all instances of `$` that aren't followed by `{` with the escape sequence.

Tested with https://github.com/Otard95/kite-issue-demo/blob/master/test.php