### PR TITLE
Pause downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -389,8 +389,8 @@
     "install-local": "vsce package && code --install-extension kite-*.vsix && rm kite-*.vsix"
   },
   "dependencies": {
-    "kite-api": "=3.20.0",
-    "kite-connector": "=3.14.0",
+    "kite-api": "=3.21.0",
+    "kite-connector": "=3.16.0",
     "md5": "^2.2.0",
     "mixpanel": "^0.5.0",
     "open": "^7.3.0",

--- a/src/constants.js
+++ b/src/constants.js
@@ -134,6 +134,8 @@ const KITE_BRANDING = " 𝕜𝕚𝕥𝕖 ";
 
 const OFFSET_ENCODING = "utf-16";
 
+const INSTALL_PAUSED_NOTIFICATION_SHOWN = "kite.hasShownInstallPausedNotification";
+
 export {
   ATTEMPTS,
   INTERVAL,
@@ -141,6 +143,7 @@ export {
   CompletionsSupport,
   SupportedExtensions,
   IsSupportedFile,
+  INSTALL_PAUSED_NOTIFICATION_SHOWN,
   CONNECT_ERROR_LOCKOUT,
   ERROR_COLOR,
   WARNING_COLOR,

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -103,11 +103,15 @@ export default class NotificationsManager {
     vscode.window
     .showInformationMessage(
       "The Kite Copilot cannot be installed for the time being. We'll notify you when it's available again.",
-      "OK"
+      "OK",
+      "Learn More"
     )
     .then(item => {
       switch (item) {
         case "OK":
+          break;
+        case "Learn More":
+          open("https://kite.com/kite-is-temporarily-unavailable/?source=vscode");
           break;
       }
     });

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -99,6 +99,44 @@ export default class NotificationsManager {
       .then(hasDone => !hasDone && openKiteTutorial('python'));
   }
 
+  static showKiteInstallPausedNotification() {
+    vscode.window
+    .showInformationMessage(
+      "The Kite Copilot cannot be installed for the time being. We'll notify you when it's available again.",
+      "OK"
+    )
+    .then(item => {
+      switch (item) {
+        case "OK":
+          break;
+      }
+    });
+  }
+
+  static showKiteInstallResumedNotification(install) {
+    vscode.window
+    .showInformationMessage(
+      "The Kite Copilot is installable again. Kite requires the Kite Copilot desktop application to provide completions and documentation. Please install it to use Kite.",
+      "Install",
+      "Learn More"
+    )
+    .then(item => {
+      switch (item) {
+        case "Install":
+          if (!install) {
+            open("https://www.kite.com/install/?utm_medium=editor&utm_source=vscode");
+            metrics.track("vscode_kite_installer_github_link_clicked")
+          } else {
+            install();
+          }
+          break;
+        case "Learn More":
+          open("https://www.kite.com/copilot/");
+          break;
+      }
+    });
+  }
+
   static showKiteInstallNotification(install) {
     metrics.track("vscode_kite_installer_notification_shown");
     vscode.window


### PR DESCRIPTION
- Check if Kite can be downloaded
- If not, show install paused notification, and store state so it doesn't get shown again.
- If download can proceed, and install paused notification was shown, show 'Kite can be installed again' message, and clear state associated with it
- On subsequent runs, the regular install notification is shown if Kite is still not installed.


<img width="463" alt="Screen Shot 2021-06-01 at 4 04 03 PM" src="https://user-images.githubusercontent.com/47993402/120401042-f77df280-c2f3-11eb-9b31-8f920159bee5.png">

<img width="459" alt="Screen Shot 2021-06-01 at 3 20 12 PM" src="https://user-images.githubusercontent.com/47993402/120401048-f9e04c80-c2f3-11eb-8660-8edad675ce57.png">
